### PR TITLE
Improve logging from python shards

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -299,6 +299,10 @@ fn shard_manager(
             "SAFETENSORS_FAST_GPU".parse().unwrap(),
             "1".to_string().parse().unwrap(),
         ),
+        (
+            "PYTHONUNBUFFERED".parse().unwrap(),
+            "1".to_string().parse().unwrap(),
+        ),
     ];
 
     // If the HUGGINGFACE_HUB_CACHE env var is set, pass it to the shard
@@ -346,6 +350,12 @@ fn shard_manager(
             return;
         }
     };
+
+    // Redirect STDOUT to the console
+    let shard_stdout = p.stdout.take().unwrap();
+    thread::spawn(move || BufReader::new(shard_stdout).lines().for_each(|line|
+        println!("Shard {}: {}", rank, line.unwrap())
+    ));
 
     let mut ready = false;
     let start_time = Instant::now();

--- a/launcher/tests/integration_tests.rs
+++ b/launcher/tests/integration_tests.rs
@@ -41,23 +41,19 @@ fn start_launcher(model_name: String, num_shard: usize, port: usize, master_port
         &argv,
         PopenConfig {
             stdout: Redirection::Pipe,
-            stderr: Redirection::Pipe,
+            stderr: Redirection::Merge,
             ..Default::default()
         },
     )
     .expect("Could not start launcher");
 
     // Redirect STDOUT and STDERR to the console
+    // (STDERR is merged into STDOUT)
     let launcher_stdout = launcher.stdout.take().unwrap();
-    let launcher_stderr = launcher.stderr.take().unwrap();
 
     thread::spawn(move || {
         let stdout = BufReader::new(launcher_stdout);
-        let stderr = BufReader::new(launcher_stderr);
         for line in stdout.lines() {
-            println!("{}", line.unwrap());
-        }
-        for line in stderr.lines() {
             println!("{}", line.unwrap());
         }
     });


### PR DESCRIPTION
I found these changes necessary to be able to do reasonable problem diagnosis.

- Ensure output from the shards makes its way to the launcher's stdout
- Log full exceptions raised by server rpc functions
- Fix stderr logging in `integration_tests.rs`