### PR TITLE
feat(server): have FlashGPTNeoXModel support HF accelerate

### DIFF
--- a/server/text_generation_server/models/custom_modeling/flash_neox_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_neox_modeling.py
@@ -505,7 +505,7 @@ class FlashGPTNeoXPreTrainedModel(PreTrainedModel):
     config_class = GPTNeoXConfig
     base_model_prefix = "gpt_neox"
     supports_gradient_checkpointing = False
-    _no_split_modules = None
+    _no_split_modules = ["FlashNeoXLayer"]
 
 
 class FlashGPTNeoXModel(FlashGPTNeoXPreTrainedModel):


### PR DESCRIPTION
It seems to work fine and loads 4-10x faster for me depending on the storage/page cache (non-sharded 20B parameter model).

However, when loaded this way, inference appears to be 10-15% slower for some reason.

Mainly opening this for discussion and to see if there are any ideas about why it would slow down inferencing.