### PR TITLE
feat(server): avoid manipulating position_ids for non-applicable models

### DIFF
--- a/server/text_generation_server/models/model.py
+++ b/server/text_generation_server/models/model.py
@@ -23,6 +23,7 @@ class Model(ABC):
         self.all_special_ids = set(tokenizer.all_special_ids)
         self.device = device
         self.decode_buffer = decode_buffer
+        self.use_position_ids = False
 
     @property
     @abstractmethod

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -39,8 +39,9 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
         return generate_pb2.ClearCacheResponse()
 
     async def Prefill(self, request, context):
+        kwargs = {"use_position_ids": True} if self.model.use_position_ids else {}
         batch = self.model.batch_type.from_pb(
-            request.batch, self.model.tokenizer, self.model.device
+            request.batch, self.model.tokenizer, self.model.device, **kwargs,
         )
 
         generations, next_batch = self.model.generate_token(batch)


### PR DESCRIPTION
Currently, position_ids are always maintained/updated in the CausalLM case but this is unnecessary for models like BLOOM which don't use them.