### PR TITLE
feat(router): Dynamic batch sizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,6 +2490,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "nohash-hasher",
+ "num",
  "opentelemetry",
  "opentelemetry-otlp",
  "rand",

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -41,6 +41,10 @@ struct Args {
     max_total_tokens: usize,
     #[clap(default_value = "32", long, env)]
     max_batch_size: usize,
+    #[clap(default_value = None, long, env)]
+    max_batch_weight: Option<usize>,
+    #[clap(default_value = None, long, env)]
+    max_prefill_weight: Option<usize>,
     #[clap(default_value = "20", long, env)]
     max_waiting_tokens: usize,
     #[clap(default_value = "3000", long, short, env)]
@@ -93,6 +97,8 @@ fn main() -> ExitCode {
         max_input_length,
         max_total_tokens,
         max_batch_size,
+        max_batch_weight,
+        max_prefill_weight,
         max_waiting_tokens,
         port,
         shard_uds_path,
@@ -391,6 +397,16 @@ fn main() -> ExitCode {
         "--tokenizer-name".to_string(),
         model_id,
     ];
+
+    if let Some(max_batch_weight) = max_batch_weight {
+        argv.push("--max-batch-weight".to_string());
+        argv.push(max_batch_weight.to_string())
+    }
+
+    if let Some(max_prefill_weight) = max_prefill_weight {
+        argv.push("--max-batch-weight".to_string());
+        argv.push(max_prefill_weight.to_string())
+    }
 
     // Model optional revision
     if let Some(ref revision) = revision {

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.26"
 metrics = "0.20.1"
 metrics-exporter-prometheus = { version = "0.11.0", features = [] }
 nohash-hasher = "0.2.0"
+num = "0.4.0"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.11.0"
 rand = "0.8.5"

--- a/router/src/infer.rs
+++ b/router/src/infer.rs
@@ -240,7 +240,6 @@ impl<B: BatchType> Infer<B> {
 /// Batches requests and sends them to the inference server
 async fn batching_task<B: BatchType>(
     mut client: ShardedClient,
-    // max_batch_size: usize,
     max_waiting_tokens: usize,
     queue: Queue<B>,
     shared: Arc<Shared>,

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -33,6 +33,10 @@ struct Args {
     max_total_tokens: usize,
     #[clap(default_value = "32", long, env)]
     max_batch_size: usize,
+    #[clap(default_value = None, long, env)]
+    max_batch_weight: Option<usize>,
+    #[clap(default_value = None, long, env)]
+    max_prefill_weight: Option<usize>,
     #[clap(default_value = "20", long, env)]
     max_waiting_tokens: usize,
     #[clap(default_value = "3000", long, short, env)]
@@ -64,6 +68,8 @@ fn main() -> Result<(), std::io::Error> {
         max_input_length,
         max_total_tokens,
         max_batch_size,
+        max_batch_weight,
+        max_prefill_weight,
         max_waiting_tokens,
         port,
         master_shard_uds_path,
@@ -169,6 +175,8 @@ fn main() -> Result<(), std::io::Error> {
                 max_input_length,
                 max_total_tokens,
                 max_batch_size,
+                max_batch_weight,
+                max_prefill_weight,
                 max_waiting_tokens,
                 sharded_client,
                 tokenizer,

--- a/router/src/queue.rs
+++ b/router/src/queue.rs
@@ -2,8 +2,9 @@ use crate::infer::InferError;
 use crate::infer::InferStreamResponse;
 use crate::validation::ValidGenerateRequest;
 use nohash_hasher::{BuildNoHashHasher, IntMap};
-use std::cmp::min;
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
+use std::ops::Add;
+use std::time::Duration;
 use text_generation_client::{Batch, Request};
 use tokio::sync::oneshot;
 use tokio::time::Instant;
@@ -14,6 +15,8 @@ use tracing::{info_span, instrument, Span};
 pub(crate) struct Entry {
     /// Request
     pub request: ValidGenerateRequest,
+    /// Count of tokens generated so far
+    pub generated_tokens: usize,
     /// Response sender to communicate between the Infer struct and the batching_task
     pub response_tx: flume::Sender<Result<InferStreamResponse, InferError>>,
     /// Span that will live as long as entry
@@ -34,12 +37,12 @@ pub(crate) struct Queue {
 }
 
 impl Queue {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(config: BatchingConfig) -> Self {
         // Create channel
         let (queue_sender, queue_receiver) = flume::unbounded();
 
         // Launch background queue task
-        tokio::spawn(queue_task(queue_receiver));
+        tokio::spawn(queue_task(queue_receiver, config));
 
         Self { queue_sender }
     }
@@ -54,21 +57,19 @@ impl Queue {
             .unwrap();
     }
 
-    // Get the next batch
+    // Get the next batch - existing batch is returned unchanged
     #[instrument(skip(self))]
     pub(crate) async fn next_batch(
         &self,
-        min_size: Option<usize>,
-        max_size: usize,
-    ) -> Option<NextBatch> {
+        entries: Option<ExistingBatch>,
+    ) -> (Option<ExistingBatch>, Option<NextBatch>) {
         // Create response channel
         let (response_sender, response_receiver) = oneshot::channel();
         // Send next batch command to the background task managing the state
         // Unwrap is safe here
         self.queue_sender
             .send(QueueCommand::NextBatch {
-                min_size,
-                max_size,
+                entries,
                 response_sender,
                 span: Span::current(),
             })
@@ -80,28 +81,37 @@ impl Queue {
 }
 
 // Background task responsible of the queue state
-async fn queue_task(receiver: flume::Receiver<QueueCommand>) {
-    let mut state = State::new();
+async fn queue_task(receiver: flume::Receiver<QueueCommand>, config: BatchingConfig) {
+    let mut state = State::new(config);
 
     while let Ok(cmd) = receiver.recv_async().await {
         match cmd {
             QueueCommand::Append(entry, span) => span.in_scope(|| state.append(entry)),
             QueueCommand::NextBatch {
-                min_size,
-                max_size,
+                entries,
                 response_sender,
                 span,
             } => span.in_scope(|| {
-                let next_batch = state.next_batch(min_size, max_size);
-                response_sender.send(next_batch).unwrap_or(());
+                let response = state.next_batch(entries);
+                response_sender.send(response).unwrap_or(());
             }),
         }
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct BatchingConfig {
+    pub(crate) size_limit: usize,
+    pub(crate) weight_limit: usize,
+    pub(crate) prefill_weight_limit: usize,
+}
+
 /// Queue State
 #[derive(Debug)]
 struct State {
+    /// Batching configuration
+    config: BatchingConfig,
+
     /// Queue entries organized in a Vec
     entries: VecDeque<(u64, Entry)>,
 
@@ -110,14 +120,46 @@ struct State {
 
     /// Id of the next batch
     next_batch_id: u64,
+
+    // Remembered size of the last batch, used to determine
+    // when entries have completed between calls to the
+    // next_batch function
+    last_seen_batch_size: usize,
+
+    // Index in the queue up to which entries have been
+    // checked to see if they can fit into the current batch.
+    // Reset to zero when any existing entries complete
+    checked_request_count: usize,
+
+    /// true if it's known that the current size of the
+    /// requests in the queue is too small to prefill an add-on batch
+    buffer_contents_insufficient: bool,
+
+    /// Just a constant empty map to reuse
+    empty_map: ExistingBatch,
 }
 
+// Could also make these configurable
+
+/// Longest that requests can be waiting before we ignore the minimum
+/// size requirement when adding to a new batch
+const MAX_WAITING_DURATION: Duration = Duration::from_secs(1);
+
+/// Maximum difference in arrival time that smaller requests can jump
+/// ahead of larger ones in the queue
+const CUTOFF_DURATION: Duration = Duration::from_secs(1);
+
 impl State {
-    fn new() -> Self {
+    fn new(config: BatchingConfig) -> Self {
         Self {
+            config,
             entries: VecDeque::with_capacity(128),
             next_id: 0,
             next_batch_id: 0,
+            last_seen_batch_size: 0,
+            checked_request_count: 0,
+            buffer_contents_insufficient: false,
+            empty_map: IntMap::default(),
         }
     }
 
@@ -134,69 +176,220 @@ impl State {
     }
 
     // Get the next batch
-    fn next_batch(&mut self, min_size: Option<usize>, max_size: usize) -> Option<NextBatch> {
-        if self.entries.is_empty() {
-            return None;
+    fn next_batch(
+        &mut self, existing_entries_opt: Option<ExistingBatch>,
+    ) -> (Option<ExistingBatch>, Option<NextBatch>) {
+
+        // Use ref to empty map in None case to simplify subsequent logic
+        let existing_entries = existing_entries_opt.as_ref().unwrap_or(&self.empty_map);
+
+        let config = &self.config;
+        let mut total_count = existing_entries.len();
+        if total_count >= config.size_limit {
+            // We are already at max batch size
+            return (existing_entries_opt, None)
         }
 
-        // Check if we have enough entries
-        if let Some(min_size) = min_size {
-            if self.entries.len() < min_size {
-                return None;
+        if total_count != self.last_seen_batch_size {
+            // Reset the count of checked requests if any completed since last check
+            self.checked_request_count = 0;
+            self.last_seen_batch_size = total_count
+        }
+
+        // Filter entries where the response receiver was dropped (== entries where the request
+        // was dropped by the client)
+        let queue_len_before = self.entries.len();
+        self.entries.retain_mut(|(_, entry)| !entry.response_tx.is_disconnected());
+        if queue_len_before != self.entries.len() {
+            // Reset the count of checked requests if any in the queue were cancelled since last check
+            self.checked_request_count = 0;
+        }
+
+        // This will generally be zero, but if no requests have been completed
+        // since last time, we don't need to reconsider those already checked
+        let mut checked_up_to_index = self.checked_request_count;
+
+        if !existing_entries.is_empty() {
+            // If we don't have any new requests in the buffer to check
+            if self.entries.len() <= checked_up_to_index ||
+                // Or the current buffer isn't large enough to satisfy the min prefill requirement
+                self.buffer_contents_insufficient && !self.next_entry_waiting_too_long() {
+                return (existing_entries_opt, None)
             }
         }
 
-        let max_batch_size = min(self.entries.len(), max_size);
+        // Indices into buffer of entries chosen to add to next batch or remove due to expiry
+        let mut chosen_indices = vec![];
+        // Indices to drop due to client cancellation
+        let mut indices_to_drop = vec![];
+        let mut btree = None;
+        let mut time_cutoff = None;
+        let mut hit_prefill_weight_limit = false;
+
+        let mut total_token_count = existing_entries.iter().map(
+            |(_, e)| e.request.stopping_parameters.max_new_tokens + e.request.truncate
+        ).sum::<u32>() as usize;
+
+        let mut prefill_size = 0;
+        // We first do a read-only pass over the queue to allow skipping over large entries
+        // that don't fit in the current batch to reach smaller entries that do
+        let mut queue_index = checked_up_to_index;
+        'queue_loop: for (entry_id, entry) in self.entries.range(queue_index..) {
+            if matches!(time_cutoff, Some(t) if entry.queue_time > t) {
+                break
+            }
+            queue_index += 1;
+            if entry.response_tx.is_disconnected() {
+                // Eject cancelled entry from queue
+                indices_to_drop.push(queue_index);
+                continue
+            }
+            // This is the index into the queue after cancelled entries
+            // have been pruned
+            checked_up_to_index += 1;
+
+            let input_len = entry.request.truncate as usize;
+            let output_len = entry.request.stopping_parameters.max_new_tokens as usize;
+            let next_total_token_count = total_token_count + input_len + output_len;
+
+            // Avoid more granular analysis if possible
+            if next_total_token_count > config.weight_limit {
+                // We aren't sure whether this next request will fit, so populate
+                // a btree with the current batch of requests, the set of
+                // requests already evaluated, and this one, and perform more
+                // granular analysis to verify that the batch shape won't exceed
+                // the limit at any point
+
+                // Allocate btree the first time it's required
+                let tree = btree.get_or_insert_with(|| {
+                    let mut t = Box::new(BTreeSet::new());
+                    // Populate with records corresponding to all existing and pending entries
+                    let pending = chosen_indices.iter()
+                        .map(|i| self.entries.get(*i).unwrap())
+                        .map(|(eid, e)| (eid, e));
+                    for (eid, e) in existing_entries.iter().chain(pending) {
+                        let generated_count = e.generated_tokens;
+                        t.insert((
+                            e.request.stopping_parameters.max_new_tokens as usize - generated_count,
+                            e.request.truncate as usize + e.generated_tokens,
+                            eid,
+                        ));
+                    }
+                    t
+                });
+                // Add the current entry
+                tree.insert((output_len, input_len, entry_id));
+
+                // Perform analysis
+                let mut in_sum = 0;
+                // Work backwards from longest projected entry
+                for (bs, (ol, il, _)) in tree.iter().rev().enumerate() {
+                    let this_ol = *ol;
+                    in_sum += *il;
+                    if this_ol <= output_len {
+                        // Check if we breach max space for this segment
+                        let token_count = in_sum + (bs + 1) * this_ol;
+                        if token_count > config.weight_limit {
+                            // Remove our tuple from the set
+                            tree.remove(&(output_len, input_len, entry_id));
+                            time_cutoff.get_or_insert_with(|| entry.queue_time.add(CUTOFF_DURATION));
+                            continue 'queue_loop
+                        }
+                    }
+                }
+            } else if let Some(tree) = btree.as_mut() {
+                // If we initialized the btree for a prior request, keep it updated
+                tree.insert((output_len, input_len, entry_id));
+            }
+            // Here, we can add this request to the batch without breaching memory limit
+
+            if config.prefill_weight_limit > 0 {
+                // Also check whether adding this request will make the batch of new requests
+                // too expensive latency-wise to perform in a single forward-pass.
+                if prefill_size + input_len > config.prefill_weight_limit {
+                    if let Some(tree) = btree.as_mut() {
+                        // Remove our tuple from the set
+                        tree.remove(&(output_len, input_len, entry_id));
+                        hit_prefill_weight_limit = true;
+                    }
+                    time_cutoff.get_or_insert_with(|| entry.queue_time.add(CUTOFF_DURATION));
+                    continue
+                }
+            }
+
+            total_token_count = next_total_token_count;
+            prefill_size += input_len;
+
+            chosen_indices.push(queue_index - 1);
+            total_count += 1;
+            if total_count >= config.size_limit {
+                break
+            }
+        }
+
+        // Drop any cancelled requests
+        if !indices_to_drop.is_empty() {
+            indices_to_drop.iter().for_each(|i| {
+                self.entries.remove(*i);
+            });
+            metrics::gauge!("tgi_queue_size", self.entries.len() as f64);
+        }
+
+        let next_batch_size = chosen_indices.len();
+        if next_batch_size == 0 {
+            // This gets reset to zero when any requests in the existing batch are removed
+            self.checked_request_count = checked_up_to_index;
+            return (existing_entries_opt, None)
+        }
+        self.checked_request_count = 0;
+
+        if !hit_prefill_weight_limit && !existing_entries.is_empty() {
+            // If this is to be added to an existing batch, ensure it meets urgency or size
+            // requirements to avoid too frequent prefills
+            if !self.next_entry_waiting_too_long() {
+                if total_token_count < config.weight_limit / 2 {
+                    // Don't add this new batch yet because it's not large enough
+                    self.checked_request_count = checked_up_to_index;
+                    self.buffer_contents_insufficient = true;
+                    return (existing_entries_opt, None)
+                }
+            }
+        }
 
         // Create span for this batch to add context to inference calls
-        let next_batch_span = info_span!(parent: None, "batch", batch_size = tracing::field::Empty);
+        let next_batch_span = info_span!(parent: None, "batch", batch_size = next_batch_size);
         next_batch_span.follows_from(&Span::current());
 
-        let mut batch_requests = Vec::with_capacity(max_batch_size);
         let mut batch_entries =
-            IntMap::with_capacity_and_hasher(max_batch_size, BuildNoHashHasher::default());
+            IntMap::with_capacity_and_hasher(next_batch_size, BuildNoHashHasher::default());
 
-        // Iterate on buffer
-        while let Some((id, mut entry)) = self.entries.pop_front() {
-            // Filter entries where the response receiver was dropped (== entries where the request
-            // was dropped by the client)
-            if entry.response_tx.is_disconnected() {
-                metrics::increment_counter!("tgi_request_failure", "err" => "dropped");
-                continue;
-            }
-
+        let some_now = Some(Instant::now());
+        let batch_requests = chosen_indices.iter().enumerate().map(|(i, index)| {
+            let (id, mut entry) = self.entries.remove(index - i).expect("bug");
             // Create a new span to link the batch back to this entry
-            let entry_batch_span = info_span!(parent: &entry.span, "infer");
+            let entry_batch_span =
+                info_span!(parent: &entry.span, "infer", batch_size = next_batch_size);
             // Add relationships
             next_batch_span.follows_from(&entry_batch_span);
             entry_batch_span.follows_from(&next_batch_span);
             // Update entry
             entry.temp_span = Some(entry_batch_span);
 
-            batch_requests.push(Request {
+            let request = Request {
                 id,
                 inputs: entry.request.inputs.clone(),
                 truncate: entry.request.truncate,
                 parameters: Some(entry.request.parameters.clone()),
                 stopping_parameters: Some(entry.request.stopping_parameters.clone()),
-            });
+            };
             // Set batch_time
-            entry.batch_time = Some(Instant::now());
+            entry.batch_time = some_now;
             // Insert in batch_entries IntMap
             batch_entries.insert(id, entry);
-
-            if batch_requests.len() == max_batch_size {
-                // We have enough requests in the batch
-                break;
-            }
-        }
+            request
+        }).collect::<Vec<Request>>();
 
         metrics::gauge!("tgi_queue_size", self.entries.len() as f64);
-
-        // Maybe all entries were dropped because their channel were closed
-        if batch_requests.is_empty() {
-            return None;
-        }
 
         // Final batch size once we dropped entries
         let size = batch_requests.len() as u32;
@@ -209,224 +402,30 @@ impl State {
         };
         // Increment batch id
         self.next_batch_id += 1;
+        self.buffer_contents_insufficient = false;
 
         metrics::histogram!("tgi_batch_next_size", batch.size as f64);
-        Some((batch_entries, batch, next_batch_span))
+        (existing_entries_opt, Some((batch_entries, batch, next_batch_span)))
+    }
+
+    /// Returns true if the entry at the front of the queue has been waiting for longer
+    /// than MAX_WAITING_DURATION
+    fn next_entry_waiting_too_long(&self) -> bool {
+        matches!(
+            self.entries.front(), Some((_, e)) if e.queue_time.elapsed() > MAX_WAITING_DURATION
+        )
     }
 }
 
+type ExistingBatch = IntMap<u64, Entry>;
 type NextBatch = (IntMap<u64, Entry>, Batch, Span);
 
 #[derive(Debug)]
 enum QueueCommand {
     Append(Entry, Span),
     NextBatch {
-        min_size: Option<usize>,
-        max_size: usize,
-        response_sender: oneshot::Sender<Option<NextBatch>>,
+        entries: Option<ExistingBatch>,
+        response_sender: oneshot::Sender<(Option<ExistingBatch>, Option<NextBatch>)>,
         span: Span,
     },
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use text_generation_client::{NextTokenChooserParameters, StoppingCriteriaParameters};
-    use tracing::info_span;
-
-    fn default_entry() -> (
-        Entry,
-        flume::Receiver<Result<InferStreamResponse, InferError>>,
-    ) {
-        let (response_tx, receiver_tx) = flume::unbounded();
-
-        let entry = Entry {
-            request: ValidGenerateRequest {
-                inputs: "".to_string(),
-                truncate: 0,
-                parameters: NextTokenChooserParameters {
-                    temperature: 0.0,
-                    top_k: 0,
-                    top_p: 0.0,
-                    typical_p: 0.0,
-                    do_sample: false,
-                    seed: 0,
-                    repetition_penalty: 0.0,
-                    watermark: false,
-                },
-                stopping_parameters: StoppingCriteriaParameters {
-                    ignore_eos_token: false,
-                    max_new_tokens: 0,
-                    stop_sequences: vec![],
-                },
-            },
-            response_tx,
-            span: info_span!("entry"),
-            temp_span: None,
-            queue_time: Instant::now(),
-            batch_time: None,
-        };
-        (entry, receiver_tx)
-    }
-
-    #[test]
-    fn test_append() {
-        let mut state = State::new();
-        let (entry, _guard) = default_entry();
-
-        assert_eq!(state.next_id, 0);
-        assert_eq!(state.entries.len(), 0);
-
-        state.append(entry);
-
-        assert_eq!(state.next_id, 1);
-        assert_eq!(state.entries.len(), 1);
-        let (id, _) = state.entries.remove(0).unwrap();
-        assert_eq!(id, 0);
-    }
-
-    #[test]
-    fn test_next_batch_empty() {
-        let mut state = State::new();
-
-        assert!(state.next_batch(None, 1).is_none());
-        assert!(state.next_batch(Some(1), 1).is_none());
-    }
-
-    #[test]
-    fn test_next_batch_min_size() {
-        let mut state = State::new();
-        let (entry1, _guard1) = default_entry();
-        let (entry2, _guard2) = default_entry();
-        state.append(entry1);
-        state.append(entry2);
-
-        let (entries, batch, _) = state.next_batch(None, 2).unwrap();
-        assert_eq!(entries.len(), 2);
-        assert!(entries.contains_key(&0));
-        assert!(entries.contains_key(&1));
-        assert!(entries.get(&0).unwrap().batch_time.is_some());
-        assert!(entries.get(&1).unwrap().batch_time.is_some());
-        assert_eq!(batch.id, 0);
-        assert_eq!(batch.size, 2);
-
-        assert_eq!(state.next_id, 2);
-        assert_eq!(state.entries.len(), 0);
-        assert_eq!(state.next_batch_id, 1);
-
-        let (entry3, _guard3) = default_entry();
-        state.append(entry3);
-
-        assert!(state.next_batch(Some(2), 2).is_none());
-
-        assert_eq!(state.next_id, 3);
-        assert_eq!(state.entries.len(), 1);
-        let (id, _) = state.entries.remove(0).unwrap();
-        assert_eq!(id, 2);
-    }
-
-    #[test]
-    fn test_next_batch_max_size() {
-        let mut state = State::new();
-        let (entry1, _guard1) = default_entry();
-        let (entry2, _guard2) = default_entry();
-        state.append(entry1);
-        state.append(entry2);
-
-        let (entries, batch, _) = state.next_batch(None, 1).unwrap();
-        assert_eq!(entries.len(), 1);
-        assert!(entries.contains_key(&0));
-        assert_eq!(batch.id, 0);
-        assert_eq!(batch.size, 1);
-
-        assert_eq!(state.next_id, 2);
-        assert_eq!(state.entries.len(), 1);
-        assert_eq!(state.next_batch_id, 1);
-
-        let (entry3, _guard3) = default_entry();
-        state.append(entry3);
-
-        let (entries, batch, _) = state.next_batch(None, 3).unwrap();
-        assert_eq!(entries.len(), 2);
-        assert!(entries.contains_key(&1));
-        assert!(entries.contains_key(&2));
-        assert_eq!(batch.id, 1);
-        assert_eq!(batch.size, 2);
-
-        assert_eq!(state.next_id, 3);
-        assert_eq!(state.entries.len(), 0);
-        assert_eq!(state.next_batch_id, 2);
-    }
-
-    #[tokio::test]
-    async fn test_queue_append() {
-        let queue = Queue::new();
-        let (entry, _guard) = default_entry();
-        queue.append(entry);
-    }
-
-    #[tokio::test]
-    async fn test_queue_next_batch_empty() {
-        let queue = Queue::new();
-
-        assert!(queue.next_batch(None, 1).await.is_none());
-        assert!(queue.next_batch(Some(1), 1).await.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_queue_next_batch_min_size() {
-        let queue = Queue::new();
-        let (entry1, _guard1) = default_entry();
-        let (entry2, _guard2) = default_entry();
-        queue.append(entry1);
-        queue.append(entry2);
-
-        let (entries, batch, _) = queue.next_batch(None, 2).await.unwrap();
-        assert_eq!(entries.len(), 2);
-        assert!(entries.contains_key(&0));
-        assert!(entries.contains_key(&1));
-        assert!(entries.get(&0).unwrap().batch_time.is_some());
-        assert!(entries.get(&1).unwrap().batch_time.is_some());
-        assert_eq!(batch.id, 0);
-        assert_eq!(batch.size, 2);
-
-        let (entry3, _guard3) = default_entry();
-        queue.append(entry3);
-
-        assert!(queue.next_batch(Some(2), 2).await.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_queue_next_batch_max_size() {
-        let queue = Queue::new();
-        let (entry1, _guard1) = default_entry();
-        let (entry2, _guard2) = default_entry();
-        queue.append(entry1);
-        queue.append(entry2);
-
-        let (entries, batch, _) = queue.next_batch(None, 1).await.unwrap();
-        assert_eq!(entries.len(), 1);
-        assert!(entries.contains_key(&0));
-        assert_eq!(batch.id, 0);
-        assert_eq!(batch.size, 1);
-
-        let (entry3, _guard3) = default_entry();
-        queue.append(entry3);
-
-        let (entries, batch, _) = queue.next_batch(None, 3).await.unwrap();
-        assert_eq!(entries.len(), 2);
-        assert!(entries.contains_key(&1));
-        assert!(entries.contains_key(&2));
-        assert_eq!(batch.id, 1);
-        assert_eq!(batch.size, 2);
-    }
-
-    #[tokio::test]
-    async fn test_queue_next_batch_dropped_receiver() {
-        let queue = Queue::new();
-        let (entry, _) = default_entry();
-        queue.append(entry);
-
-        assert!(queue.next_batch(None, 1).await.is_none());
-    }
 }

--- a/router/src/queue.rs
+++ b/router/src/queue.rs
@@ -456,7 +456,7 @@ impl<B: BatchType> State<B> {
 
             batch_stats = next_stats;
 
-            chosen_indices.push(queue_index - 1);
+            chosen_indices.push(checked_up_to_index - 1);
             total_count += 1;
             if total_count >= config.size_limit {
                 break

--- a/router/src/queue.rs
+++ b/router/src/queue.rs
@@ -375,7 +375,7 @@ impl<B: BatchType> State<B> {
             queue_index += 1;
             if entry.response_tx.is_disconnected() {
                 // Eject cancelled entry from queue
-                indices_to_drop.push(queue_index);
+                indices_to_drop.push(queue_index - 1);
                 continue
             }
             // This is the index into the queue after cancelled entries
@@ -465,7 +465,8 @@ impl<B: BatchType> State<B> {
 
         // Drop any cancelled requests
         if !indices_to_drop.is_empty() {
-            indices_to_drop.iter().for_each(|i| {
+            // Iterate in reverse so that indices remain correct
+            indices_to_drop.iter().rev().for_each(|i| {
                 self.entries.remove(*i);
             });
             metrics::gauge!("tgi_queue_size", self.entries.len() as f64);

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -635,7 +635,7 @@ async fn do_run<B: BatchType>(
     validation_workers: usize,
     addr: SocketAddr,
     allow_origin: Option<AllowOrigin>,
-    _batch_type: B,
+    batch_type: B,
 ) {
     // OpenAPI documentation
     #[derive(OpenApi)]
@@ -701,7 +701,7 @@ async fn do_run<B: BatchType>(
         max_prefill_weight,
         max_waiting_tokens,
         max_concurrent_requests,
-        FlashBatch{}
+        batch_type,
     );
 
     // Duration buckets

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -505,6 +505,8 @@ pub async fn run(
     max_input_length: usize,
     max_total_tokens: usize,
     max_batch_size: usize,
+    max_batch_weight: Option<usize>,
+    max_prefill_weight: Option<usize>,
     max_waiting_tokens: usize,
     client: ShardedClient,
     tokenizer: Option<Tokenizer>,
@@ -552,6 +554,15 @@ pub async fn run(
     )]
     struct ApiDoc;
 
+    // If max batch weight is not set, infer from max batch size and max seq length
+    let max_batch_weight = max_batch_weight
+        .unwrap_or(max_batch_size * max_total_tokens);
+    let max_prefill_weight = max_prefill_weight.unwrap_or_default();
+
+    if max_total_tokens > max_batch_weight {
+        panic!("max_total_tokens cannot be greater than max_batch_weight");
+    }
+
     // Create state
     let validation = Validation::new(
         validation_workers,
@@ -565,6 +576,8 @@ pub async fn run(
         client,
         validation,
         max_batch_size,
+        max_batch_weight,
+        max_prefill_weight,
         max_waiting_tokens,
         max_concurrent_requests,
     );


### PR DESCRIPTION
#### Motivation

Currently to avoid OOM you must set a "worst case" max batch size based on the desired max sequence length. This means that (a) throughput is unnecessarily limited when there are many shorter sequences and (b) you have to be pretty conservative about the max context length offered.

These changes introduce a maximum batch "weight" parameter which in the flash attention case corresponds to a maximum total number of tokens in the batch. The idea is that this is roughly proportional to the memory requirement.
- Batches are filled taking both the input lengths and max new tokens of existing and new requests into account
- A "projection" is done when evaluating each next request in the queue for admission into the batch, to determine whether  the max batch weight will ever be exceeded in future assuming the worst case of all requests running to their `max_new_tokens` values
- As long as they did not arrive too far behind, smaller requests can jump ahead of larger ones if the larger one doesn't fit in the batch but the later smaller one does
- You can optionally set a separate "max prefill weight" to limit how many tokens can be prefilled at once. This is to help avoid long delays where no tokens are produced.

If `max_batch_weight` is not set, it just infers this from the `max_batch_size` and `max_total_tokens` args. In this case it should behave roughly the same as it does now, so could hopefully be a "non breaking" change for existing configurations

It turns out to be simpler to configure for a particular model/GPU. The precise values for `max_batch_size` and `max_sequence_length` no longer matter much, they can both be set quite high. You just need to determine one number (the max weight / total tokens), which is easy to do with minimal experimentation.

We have been using this successfully for a while now and it means we can support a much higher throughput / volume of users with the same hardware while offering larger context lengths. For example, we have a deployment of GPT-NeoX 20B on one 80GB A100 with the max batch size set to **256** and the max sequence length (max_total_tokens) set to **8192**. The actual batch size flexes automatically as needed. Our `max_batch_weight` setting for this is 10k.

#### Details/caveats

- I have ported this from my internal fork and not yet tested this branch
- ~I've only included the implementation for the flash attention case so far. The additions to generalize to the regular attention case aren't very big (we run non flash-attention models with this too), but I thought this was probably complicated enough to start with. It will need to support general case of course before actually being included.~
- Some of the logic (e.g. related to the extra fields in the queue state) is to cut down on the overhead of repeated analysis - most calls to `next_batch` should return immediately before getting into the more complex logic.
- Since the queue's `next_batch` function now takes the current entries map instead of a min and max, the tests in `queue.rs` would need updating, so I just removed them for now.
- Though it should be fully-functional please consider it still wip - if you are interested, more cleanup/rework can be done