### PR TITLE
Specify response schema for compat_generate

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -33,7 +33,14 @@
         },
         "responses": {
           "200": {
-            "description": "See /generate or /generate_stream"
+            "description": "Generated Text",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateResponse"
+                }
+              }
+            }
           },
           "422": {
             "description": "Input validation error",


### PR DESCRIPTION
We are generating an Elixir client from the OAPI spec.

Since there is no response schema reference for `/compat_generate`, the generated clients [currently output a `nil` for its response type](https://github.com/fmops/oapi_hf/blob/a7a7b55086a093a3d4306c2f30d90aae773bb233/lib/text_generation_inference/text_generation_inference.ex#L24).

This PR fixes this by adding the `GenerateResponse` schema to it.