### PR TITLE
feat(router): Adding response schema for compat_generate

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -37,7 +37,11 @@ use utoipa_swagger_ui::SwaggerUi;
     path = "/",
     request_body = CompatGenerateRequest,
     responses(
-        (status = 200, description = "See /generate or /generate_stream"),
+        (status = 200, description = "See /generate or /generate_stream",
+            content(
+                ("application/json" = GenerateResponse),
+                ("text/event-stream" = StreamResponse),
+            )),
         (status = 424, description = "Generation Error", body = ErrorResponse,
             example = json ! ({"error": "Request failed during generation"})),
         (status = 429, description = "Model is overloaded", body = ErrorResponse,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds response schema to compat_generate based on the `content_type`. Multiple content types and schema are added to `200` response code for the compat generate path and we can see the drop down for the content type in Swagger UI. Change the content type to display respective response schema and examples.

## Screenshots:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/9410663/236676168-23c05211-3e4a-4007-bbcf-a51f01cbe2b3.png">

<img width="595" alt="image" src="https://user-images.githubusercontent.com/9410663/236676074-ddd1821e-8b70-4a90-8374-f96661acc595.png">




## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
