### PR TITLE
[python] fix: Fix BLOOM's embedding mapping for deepspeed chat

### DIFF
--- a/server/text_generation_server/models/bloom.py
+++ b/server/text_generation_server/models/bloom.py
@@ -255,7 +255,7 @@ class BLOOMSharded(BLOOM):
                         raise ValueError(f"Unexpected quantize `{quantize}`")
 
                     module._parameters[param_name] = tensor
-                    if name == "word_embeddings.weight":
+                    if "word_embeddings.weight" in name:
                         model.lm_head._parameters["weight"] = tensor
 
     def forward(


### PR DESCRIPTION
# What does this PR do?
This PR makes BLOOM model trained on DeepSpeed Chat can be parallelized.
DeepSpeed Chat saves checkpoint like "transformer.word_embedding.weight". so I got an error in this part.

Fixes # (issue)
#399 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [] Did you write any new necessary tests?


## Who can review?
@OlivierDehaene 
