### PR TITLE
feat(router): add header option to disable buffering for the generate_stream response

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -351,6 +351,7 @@ async fn generate_stream(
         "x-compute-characters",
         compute_characters.to_string().parse().unwrap(),
     );
+    headers.insert("X-Accel-Buffering", "no".parse().unwrap());
 
     let stream = async_stream::stream! {
         // Inference


### PR DESCRIPTION
# This PR adds an http header option to disable buffering for the generate_stream endpoint response stream.

Problem: If a model is run behind a proxy server such as nginx that has buffering enabled then the response stream from generate_stream gets aggregated into a single response which basically disables streaming. Instead of getting a chunked response where each token is presented over time the response presents everything all at once. 

Solution: This change adds the `X-Accel-Buffering` http header which disables buffering for the generate_stream response, allowing the response to stream properly.



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@OlivierDehaene

