### PR TITLE
Automatically map deduplicated safetensors weights to their original values

### DIFF
--- a/server/text_generation_server/models/flash_rw.py
+++ b/server/text_generation_server/models/flash_rw.py
@@ -48,7 +48,13 @@ class FlashRWSharded(FlashCausalLM):
 
         torch.distributed.barrier(group=self.process_group)
         filenames = weight_files(model_id, revision=revision, extension=".safetensors")
-        weights = Weights(filenames, device, dtype, process_group=self.process_group)
+        weights = Weights(
+            filenames,
+            device,
+            dtype,
+            process_group=self.process_group,
+            aliases={"transformer.word_embeddings.weight": ["lm_head.weight"]},
+        )
 
         config.quantize = quantize
 

--- a/server/text_generation_server/utils/weights.py
+++ b/server/text_generation_server/utils/weights.py
@@ -7,10 +7,8 @@ import torch
 class Weights:
     def __init__(self, filenames: List[Path], device, dtype, process_group, aliases: Optional[Dict[str, List[str]]]=None):
         routing = {}
-        metadata = {}
         for filename in filenames:
             with safe_open(filename, framework="pytorch") as f:
-                metadata |= f.metadata()
                 for k in f.keys():
                     if k in routing:
                         raise RuntimeError(
@@ -19,7 +17,6 @@ class Weights:
                     routing[k] = filename
         if aliases is None:
             aliases = {}
-        self.metadata = metadata
         self.aliases = aliases
         self.routing = routing
         self.device = device
@@ -35,8 +32,6 @@ class Weights:
         return self._handles[filename]
 
     def get_filename(self, tensor_name: str) -> (str, str):
-        if tensor_name in self.metadata:
-            tensor_name = self.metadata[tensor_name]
         filename = self.routing.get(tensor_name, None)
         if filename is None:
             aliases = self.aliases.get(tensor_name, [])

--- a/server/text_generation_server/utils/weights.py
+++ b/server/text_generation_server/utils/weights.py
@@ -7,8 +7,10 @@ import torch
 class Weights:
     def __init__(self, filenames: List[Path], device, dtype, process_group, aliases: Optional[Dict[str, List[str]]]=None):
         routing = {}
+        metadata = {}
         for filename in filenames:
             with safe_open(filename, framework="pytorch") as f:
+                metadata |= f.metadata()
                 for k in f.keys():
                     if k in routing:
                         raise RuntimeError(
@@ -17,6 +19,7 @@ class Weights:
                     routing[k] = filename
         if aliases is None:
             aliases = {}
+        self.metadata = metadata
         self.aliases = aliases
         self.routing = routing
         self.device = device
@@ -32,6 +35,8 @@ class Weights:
         return self._handles[filename]
 
     def get_filename(self, tensor_name: str) -> (str, str):
+        if tensor_name in self.metadata:
+            tensor_name = self.metadata[tensor_name]
         filename = self.routing.get(tensor_name, None)
         if filename is None:
             aliases = self.aliases.get(tensor_name, [])


### PR DESCRIPTION
# What does this PR do?

This PR automatically points tensors that were removed due to deduplication to their still existing twin.

In `server.text_generation_server.utils.convert.py#convert_file`, tensors that have a value equal to another tensor are removed from the list of weights. Their name, and the name of the still-existing "twin" are logged to the "metadata" dictionary. However, this dictionary was not yet used during loading. This requires explicit in-code remapping when loading the models (as mentioned in the docstring).

This PR adds some simple code to check, during loading, if a weight is one of those removed weights. It then automatically retrieves the values of its still-existing "twin" instead.

## What does this fix?
We currently cannot load `h2oai/h2ogpt-oig-oasst1-falcon-40b` with the unmodified server, since the `transformer.word_embeddings.weight` weight is equal to `lm_head.weight` and is automatically removed. The falcon code, however, still expects this weight to exist. I could have also added some extra checks to the model itself, though that would only be a workaround.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
