### PR TITLE
First upgrade pip then run pip

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -3,7 +3,7 @@ include Makefile-flash-att
 unit-tests:
 	pytest -s -vv -m "not private" tests
 
-gen-server:
+gen-server: upgrade-pip
 	# Compile protos
 	pip install grpcio-tools==1.51.1 mypy-protobuf==3.4.0 'types-protobuf>=3.20.4' --no-cache-dir
 	mkdir text_generation_server/pb || true
@@ -12,12 +12,14 @@ gen-server:
 	find text_generation_server/pb/ -type f -name "*.py" -print0 -exec sed -i -e 's/^\(import.*pb2\)/from . \1/g' {} \;
 	touch text_generation_server/pb/__init__.py
 
-install-torch:
+install-torch: upgrade-pip
 	# Install specific version of torch
 	pip install torch --extra-index-url https://download.pytorch.org/whl/cu118 --no-cache-dir
 
-install: gen-server install-torch
+upgrade-pip:
 	pip install pip --upgrade
+
+install: gen-server install-torch upgrade-pip
 	pip install -r requirements.txt
 	pip install -e ".[bnb, accelerate]"
 


### PR DESCRIPTION
Currently it will execute gen-server and install-transformers first, and then start upgrading pip. It should first upgrade pip.

# What does this PR do?

Make sure pip is updated


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
 
@OlivierDehaene OR @Narsil
 