### PR TITLE
enh: Adding additional response header X-Total-Tokens

### DIFF
--- a/load_tests/starcoder_load.js
+++ b/load_tests/starcoder_load.js
@@ -55,6 +55,7 @@ export default function () {
 
     if (res.status === 200) {
         totalTime.add(res.headers["X-Total-Time"]);
+        totalTokens.add(res.headers["X-Total-Tokens"]);
         validationTime.add(res.headers["X-Validation-Time"]);
         queueTime.add(res.headers["X-Queue-Time"]);
         inferenceTime.add(res.headers["X-Inference-Time"]);

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -242,6 +242,10 @@ async fn generate(
         total_time.as_millis().to_string().parse().unwrap(),
     );
     headers.insert(
+        "x-total-tokens",
+        response.generated_text.generated_tokens.to_string().parse().unwrap(),
+    );
+    headers.insert(
         "x-validation-time",
         validation_time.as_millis().to_string().parse().unwrap(),
     );


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/text-generation-inference/issues/637

This PR adds an additional response header `x-total-tokens` which returns the total generated tokens for a specific request.  The reason for adding this is so generated tokens can be output an access log without having to parse the full body.  This log can then be used to update rate limiting rules for a given user.  

Specifically I would like to have Istio send [access logs](https://istio.io/latest/docs/tasks/observability/logs/access-log/) to a service that updates a cache.

There are no other tests or docs related to response headers, so I haven't made any changes for these, but can add if there is an easy way to do so.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@OlivierDehaene tagging you since you added all the [original](https://github.com/huggingface/text-generation-inference/commit/c8378933700e3b2b66534ca89c53a69c7b9468d3) response headers.