### PR TITLE
GPTQ Env vars: catch correct type of error

### DIFF
--- a/server/text_generation_server/utils/weights.py
+++ b/server/text_generation_server/utils/weights.py
@@ -127,8 +127,8 @@ class Weights:
                 try:
                     import os
 
-                    bits = int(os.getenv("GTPQ_BITS"))
-                    groupsize = int(os.getenv("GTPQ_GROUPSIZE"))
+                    bits = int(os.getenv("GPTQ_BITS"))
+                    groupsize = int(os.getenv("GPTQ_GROUPSIZE"))
                 except Exception:
                     raise e
             weight = (qweight, qzeros, scales, g_idx, bits, groupsize)
@@ -149,8 +149,17 @@ class Weights:
             scales = self.get_tensor(f"{prefix}.scales")
             g_idx = self.get_sharded(f"{prefix}.g_idx", dim=0)
 
-            bits = self.get_tensor("gptq_bits").item()
-            groupsize = self.get_tensor("gptq_groupsize").item()
+            try:
+                bits = self.get_tensor("gptq_bits").item()
+                groupsize = self.get_tensor("gptq_groupsize").item()
+            except SafetensorError as e:
+                try:
+                    import os
+
+                    bits = int(os.getenv("GPTQ_BITS"))
+                    groupsize = int(os.getenv("GPTQ_GROUPSIZE"))
+                except Exception:
+                    raise e
 
             weight = (qweight, qzeros, scales, g_idx, bits, groupsize)
         else:

--- a/server/text_generation_server/utils/weights.py
+++ b/server/text_generation_server/utils/weights.py
@@ -130,7 +130,7 @@ class Weights:
             try:
                 bits = self.get_tensor("gptq_bits").item()
                 groupsize = self.get_tensor("gptq_groupsize").item()
-            except SafetensorError as e:
+            except [SafetensorError, RuntimeError] as e:
                 try:
                     import os
 
@@ -159,7 +159,7 @@ class Weights:
             try:
                 bits = self.get_tensor("gptq_bits").item()
                 groupsize = self.get_tensor("gptq_groupsize").item()
-            except SafetensorError as e:
+            except [SafetensorError, RuntimeError] as e:
                 try:
                     import os
 

--- a/server/text_generation_server/utils/weights.py
+++ b/server/text_generation_server/utils/weights.py
@@ -130,7 +130,7 @@ class Weights:
             try:
                 bits = self.get_tensor("gptq_bits").item()
                 groupsize = self.get_tensor("gptq_groupsize").item()
-            except [SafetensorError, RuntimeError] as e:
+            except (SafetensorError, RuntimeError) as e:
                 try:
                     import os
 
@@ -159,7 +159,7 @@ class Weights:
             try:
                 bits = self.get_tensor("gptq_bits").item()
                 groupsize = self.get_tensor("gptq_groupsize").item()
-            except [SafetensorError, RuntimeError] as e:
+            except (SafetensorError, RuntimeError) as e:
                 try:
                     import os
 


### PR DESCRIPTION
# What does this PR do?

When passing in environment variables like gptq_bits, we still get errors thrown from TGI because the try/catch block is catching the wrong type of error. This PR aims to fix that.

@Narsil - let me know if this is how you want this formatted. My Python is a little shaky, so I hope this syntax is correct.