### PR TITLE
fix(server): 2-stage warmup for sharded models

### DIFF
--- a/proto/generate.proto
+++ b/proto/generate.proto
@@ -198,6 +198,8 @@ message DecodeResponse {
 message WarmupRequest {
     /// Batch to warmup on
     Batch batch = 1;
+    /// Maximum number of tokens that the client will send
+    optional uint32 max_total_tokens = 2;
 }
 
 /// Empty response

--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -103,6 +103,7 @@ impl Client {
         &mut self,
         max_input_length: u32,
         max_prefill_tokens: u32,
+        max_total_tokens: Option<u32>,
     ) -> Result<Option<u32>> {
         let mut n_tokens = 0;
         let mut requests = Vec::new();
@@ -142,7 +143,7 @@ impl Client {
             max_tokens: 0,
         };
 
-        let request = tonic::Request::new(WarmupRequest { batch: Some(batch) }).inject_context();
+        let request = tonic::Request::new(WarmupRequest { batch: Some(batch), max_total_tokens, }).inject_context();
         let response = self.stub.warmup(request).await?.into_inner();
         Ok(response.max_supported_total_tokens)
     }

--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -718,7 +718,7 @@ class FlashCausalLM(Model):
 
         torch.cuda.empty_cache()
         try:
-            if max_total_tokens is None:
+            if not max_total_tokens:
                 num_blocks = batch.blocks
             else:
                 num_blocks = math.ceil(max_total_tokens / BLOCK_SIZE)
@@ -739,8 +739,8 @@ class FlashCausalLM(Model):
 
         torch.cuda.synchronize(self.device)
 
-        if max_total_tokens is not None:
-            return num_blocks
+        if max_total_tokens:
+            return int(num_blocks * BLOCK_SIZE)
 
         # Inspired by the original implementation in [vllm](https://github.com/vllm-project/vllm)
         # Calculate the number of blocks that can be allocated with the free memory

--- a/server/text_generation_server/models/model.py
+++ b/server/text_generation_server/models/model.py
@@ -57,7 +57,7 @@ class Model(ABC):
     def generate_token(self, batch: B) -> Tuple[List[GeneratedText], Optional[B]]:
         raise NotImplementedError
 
-    def warmup(self, batch: B) -> Optional[int]:
+    def warmup(self, batch: B, max_total_tokens: Optional[int]) -> Optional[int]:
         self.generate_token(batch)
         return None
 

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -58,7 +58,6 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
         batch = self.model.batch_type.from_pb(
             request.batch, self.model.tokenizer, self.model.dtype, self.model.device
         )
-        logger.info(f"Warmup {(batch, request.max_total_tokens)}")
         max_supported_total_tokens = self.model.warmup(batch, request.max_total_tokens)
 
         return generate_pb2.WarmupResponse(

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -58,7 +58,8 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
         batch = self.model.batch_type.from_pb(
             request.batch, self.model.tokenizer, self.model.dtype, self.model.device
         )
-        max_supported_total_tokens = self.model.warmup(batch)
+        logger.info(f"Warmup {(batch, request.max_total_tokens)}")
+        max_supported_total_tokens = self.model.warmup(batch, request.max_total_tokens)
 
         return generate_pb2.WarmupResponse(
             max_supported_total_tokens=max_supported_total_tokens


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/text-generation-inference/pull/630 introduced logic to automatically derive `max_batch_total_tokens` from GPU memory. However, when using a sharded model, it is possible for different shards to return different supported `max_batch_total_tokens` values. Current logic assumes they are identical, which can lead to OOM issues later.

This PR introduces a 2-stage warmup process intended to fix this issue. First, the current warmup logic is applied and used to derive the `max_batch_total_tokens` on all shards. Next, instead of picking the first response, the smallest of the derived values is picked. Finally, to ensure consistent environment across all workers, the warmup is ran again, with the smallest derived value.

This ensures that the cache managers across workers allocate the same amount of memory, preventing OOM issues.

I am not experienced with Rust and would welcome any feedback.

As an optimization, we could skip the `generate_token` step in the second warmup iteration. I was unsure what would be the best way to do that without introducing a new method, however.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene

 -->
