### PR TITLE
Fix pytorch version of CUDA 11.7 to 11.8

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -59,6 +59,7 @@ six==1.16.0 ; python_version >= "3.9" and python_version < "4.0"
 sympy==1.12 ; python_version >= "3.9" and python_version < "4.0"
 texttable==1.6.7 ; python_version >= "3.9" and python_version < "4.0"
 tokenizers==0.13.3 ; python_version >= "3.9" and python_version < "4.0"
+--extra-index-url https://download.pytorch.org/whl/cu118
 torch==2.0.1 ; python_version >= "3.9" and python_version < "4.0"
 tqdm==4.65.0 ; python_version >= "3.9" and python_version < "4.0"
 transformers==4.29.2 ; python_version >= "3.9" and python_version < "4.0"


### PR DESCRIPTION
# Fix pytorch version of CUDA 11.7 to 11.8
This fixes compatibility with H100 GPUs.
Tested with Falcon-40b on DGX H100.

Completely removing torch from the requirements.txt also works. Looks like this overwrites the built version of torch.

Fixes #739 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil 
