### PR TITLE
Added support for `logit_bias` in token generation [WIP / Looking for Feedback]

### DIFF
--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -42,6 +42,7 @@ pub async fn run(
         seed: 0,
         repetition_penalty: repetition_penalty.unwrap_or(1.0),
         watermark,
+        logit_bias: vec![],
     };
 
     // Initialize terminal properties

--- a/proto/generate.proto
+++ b/proto/generate.proto
@@ -66,6 +66,16 @@ message NextTokenChooserParameters {
     float repetition_penalty = 7;
     /// token watermarking using "A Watermark for Large Language Models"
     bool watermark = 8;
+    /// bias towards certain token sequences
+    repeated LogitBias logit_bias = 9;
+}
+
+/// a token sequence and its bias
+message LogitBias {
+    /// string to bias towards (may be more than one token)
+    string string = 1;
+    /// bias for the string
+    float bias = 2;
 }
 
 message StoppingCriteriaParameters {

--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -124,6 +124,7 @@ impl Client {
                     seed: 0,
                     repetition_penalty: 1.2,
                     watermark: true,
+                    logit_bias: vec![],
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {
                     max_new_tokens: 2,

--- a/router/client/src/lib.rs
+++ b/router/client/src/lib.rs
@@ -10,7 +10,7 @@ pub use pb::generate::v1::HealthResponse;
 pub use pb::generate::v1::InfoResponse as ShardInfo;
 pub use pb::generate::v1::{
     Batch, CachedBatch, FinishReason, GeneratedText, Generation, NextTokenChooserParameters,
-    PrefillTokens, Request, StoppingCriteriaParameters,
+    PrefillTokens, Request, StoppingCriteriaParameters, LogitBias
 };
 pub use sharded_client::ShardedClient;
 use thiserror::Error;

--- a/router/src/health.rs
+++ b/router/src/health.rs
@@ -44,6 +44,7 @@ impl Health {
                     seed: 0,
                     repetition_penalty: 1.0,
                     watermark: false,
+                    logit_bias: vec![],
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {
                     max_new_tokens: 1,

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -5,6 +5,7 @@ mod queue;
 pub mod server;
 mod validation;
 
+use std::collections::BTreeMap;
 use infer::Infer;
 use queue::{Entry, Queue};
 use serde::{Deserialize, Serialize};
@@ -113,7 +114,7 @@ pub(crate) struct GenerateParameters {
     #[schema(nullable = true, default = "null", example = false)]
     pub return_full_text: Option<bool>,
     #[serde(default)]
-    #[schema(inline, max_items = 4, example = json ! (["photographer"]))]
+    #[schema(inline, max_items = 4, example = json!(["photographer"]))]
     pub stop: Vec<String>,
     #[serde(default)]
     #[schema(nullable = true, default = "null", example = "null")]
@@ -135,6 +136,9 @@ pub(crate) struct GenerateParameters {
         example = "null"
     )]
     pub seed: Option<u64>,
+    #[serde(default)]
+    #[schema(default=json!({}), example=json!({"hello": 0.5}))]
+    pub logit_bias: BTreeMap<String, f32>
 }
 
 fn default_max_new_tokens() -> u32 {
@@ -158,6 +162,7 @@ fn default_parameters() -> GenerateParameters {
         details: false,
         decoder_input_details: false,
         seed: None,
+        logit_bias: BTreeMap::new(),
     }
 }
 

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -114,7 +114,7 @@ pub(crate) struct GenerateParameters {
     #[schema(nullable = true, default = "null", example = false)]
     pub return_full_text: Option<bool>,
     #[serde(default)]
-    #[schema(inline, max_items = 4, example = json!(["photographer"]))]
+    #[schema(inline, max_items = 4, example = json ! (["photographer"]))]
     pub stop: Vec<String>,
     #[serde(default)]
     #[schema(nullable = true, default = "null", example = "null")]

--- a/router/src/queue.rs
+++ b/router/src/queue.rs
@@ -322,6 +322,7 @@ mod tests {
                     seed: 0,
                     repetition_penalty: 0.0,
                     watermark: false,
+                    logit_bias: vec![],
                 },
                 stopping_parameters: StoppingCriteriaParameters {
                     ignore_eos_token: false,

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -83,7 +83,7 @@ class CausalLMBatch(Batch):
         for i, r in enumerate(pb.requests):
             requests_idx_mapping[r.id] = i
             inputs.append(r.inputs)
-            next_token_choosers.append(NextTokenChooser.from_pb(r.parameters, device))
+            next_token_choosers.append(NextTokenChooser.from_pb(r.parameters, device, tokenizer))
             stopping_criteria = StoppingCriteria.from_pb(
                 r.stopping_parameters, tokenizer
             )

--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -303,7 +303,7 @@ class FlashCausalLMBatch(Batch):
             max_length = max(max_length, input_length + max_new_tokens)
 
         next_token_chooser = HeterogeneousNextTokenChooser.from_pb(
-            next_token_chooser_parameters, dtype, device
+            next_token_chooser_parameters, dtype, device, tokenizer
         )
         start_slots = torch.tensor(start_slots, dtype=torch.int64)
 
@@ -634,6 +634,8 @@ class FlashCausalLMBatch(Batch):
             next_token_chooser_parameters,
             dtype=batches[0].next_token_chooser.dtype,
             device=batches[0].next_token_chooser.device,
+            # todo - determine how to obtain access to a tokenizer here
+            tokenizer=...
         )
 
         # Needed to avoid dropping blocks when the batches will go out of scope

--- a/server/text_generation_server/models/galactica.py
+++ b/server/text_generation_server/models/galactica.py
@@ -91,7 +91,7 @@ class GalacticaCausalLMBatch(CausalLMBatch):
             requests_idx_mapping[r.id] = i
             # Add escape_custom_split_sequence to the CausalLMBatch logic
             inputs.append(escape_custom_split_sequence(r.inputs))
-            next_token_choosers.append(NextTokenChooser.from_pb(r.parameters, device))
+            next_token_choosers.append(NextTokenChooser.from_pb(r.parameters, device, tokenizer))
             stopping_criteria = StoppingCriteria.from_pb(
                 r.stopping_parameters, tokenizer
             )

--- a/server/text_generation_server/models/seq2seq_lm.py
+++ b/server/text_generation_server/models/seq2seq_lm.py
@@ -92,7 +92,7 @@ class Seq2SeqLMBatch(Batch):
             inputs.append(r.inputs)
             requests_idx_mapping[r.id] = i
             decoder_input_lengths.append(1)
-            next_token_choosers.append(NextTokenChooser.from_pb(r.parameters, device))
+            next_token_choosers.append(NextTokenChooser.from_pb(r.parameters, device, tokenizer))
             stopping_criteria = StoppingCriteria.from_pb(
                 r.stopping_parameters, tokenizer
             )

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -33,7 +33,7 @@ class NextTokenChooser:
             do_sample=False,
             seed=0,
             device="cpu",
-            logit_bias=None,
+            logit_bias={},
     ):
         self.watermark_processor = (
             WatermarkLogitsProcessor(device=device) if watermark else None
@@ -85,6 +85,7 @@ class NextTokenChooser:
             cls,
             pb: generate_pb2.NextTokenChooserParameters,
             device: torch.device,
+            tokenizer: PreTrainedTokenizerBase,
     ) -> "NextTokenChooser":
         return NextTokenChooser(
             watermark=pb.watermark,
@@ -96,7 +97,7 @@ class NextTokenChooser:
             do_sample=pb.do_sample,
             seed=pb.seed,
             device=device,
-            logit_bias=pb.logit_bias,
+            logit_bias=dict([(tuple(tokenizer.encode(bias.string, add_special_tokens=False).input_ids[0]), bias.bias) for  bias in pb.logit_bias]),
         )
 
 
@@ -285,6 +286,7 @@ bias
             pb: List[generate_pb2.NextTokenChooserParameters],
             dtype: torch.dtype,
             device: torch.device,
+            tokenizer: PreTrainedTokenizerBase,
     ) -> "HeterogeneousNextTokenChooser":
         return HeterogeneousNextTokenChooser(
             watermark=[pb_.watermark for pb_ in pb],
@@ -297,7 +299,7 @@ bias
             seeds=[pb_.seed for pb_ in pb],
             device=device,
             dtype=dtype,
-            logit_bias={},
+            logit_bias=[dict([(tuple(tokenizer.encode(bias.string, add_special_tokens=False).input_ids[0]), bias.bias) for bias in pb_.logit_bias])  for pb_ in pb],
         )
 
 

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -23,17 +23,17 @@ from text_generation_server.utils.logits_process import (
 
 class NextTokenChooser:
     def __init__(
-            self,
-            watermark=False,
-            temperature=1.0,
-            repetition_penalty=1.0,
-            top_k=None,
-            top_p=None,
-            typical_p=None,
-            do_sample=False,
-            seed=0,
-            device="cpu",
-            logit_bias={},
+        self,
+        watermark=False,
+        temperature=1.0,
+        repetition_penalty=1.0,
+        top_k=None,
+        top_p=None,
+        typical_p=None,
+        do_sample=False,
+        seed=0,
+        device="cpu",
+        logit_bias={},
     ):
         self.watermark_processor = (
             WatermarkLogitsProcessor(device=device) if watermark else None
@@ -97,7 +97,9 @@ class NextTokenChooser:
             do_sample=pb.do_sample,
             seed=pb.seed,
             device=device,
-            logit_bias=dict([(tuple(tokenizer.encode(bias.string, add_special_tokens=False).input_ids[0]), bias.bias) for  bias in pb.logit_bias]),
+            logit_bias=dict(
+                [(tuple(tokenizer.encode(bias.string, add_special_tokens=False).input_ids[0]), bias.bias) for bias in
+                 pb.logit_bias]),
         )
 
 
@@ -199,7 +201,7 @@ class HeterogeneousNextTokenChooser:
         self.sequence_bias_logits_processor = (
             HeterogeneousProcessorWrapper({
                 i: SequenceBiasLogitsProcessor(
-bias
+                    bias
                 )
                 for i, bias in enumerate(logit_bias)
                 if any([bias[k] != 0.0 for k in bias])
@@ -299,7 +301,9 @@ bias
             seeds=[pb_.seed for pb_ in pb],
             device=device,
             dtype=dtype,
-            logit_bias=[dict([(tuple(tokenizer.encode(bias.string, add_special_tokens=False).input_ids[0]), bias.bias) for bias in pb_.logit_bias])  for pb_ in pb],
+            logit_bias=[dict(
+                [(tuple(tokenizer.encode(bias.string, add_special_tokens=False).input_ids[0]), bias.bias) for bias in
+                 pb_.logit_bias]) for pb_ in pb],
         )
 
 

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -23,17 +23,17 @@ from text_generation_server.utils.logits_process import (
 
 class NextTokenChooser:
     def __init__(
-        self,
-        watermark=False,
-        temperature=1.0,
-        repetition_penalty=1.0,
-        top_k=None,
-        top_p=None,
-        typical_p=None,
-        do_sample=False,
-        seed=0,
-        device="cpu",
-        logit_bias=None,
+            self,
+            watermark=False,
+            temperature=1.0,
+            repetition_penalty=1.0,
+            top_k=None,
+            top_p=None,
+            typical_p=None,
+            do_sample=False,
+            seed=0,
+            device="cpu",
+            logit_bias=None,
     ):
         self.watermark_processor = (
             WatermarkLogitsProcessor(device=device) if watermark else None
@@ -44,14 +44,14 @@ class NextTokenChooser:
             else None
         )
         self.sequence_bias_logits_processor = (
-            SequenceBiasLogitsProcessor(sequence_bias = logit_bias)
+            SequenceBiasLogitsProcessor(sequence_bias=logit_bias)
         ) if logit_bias and any([logit_bias[k] != 0.0 for k in logit_bias]) else None
 
         has_warpers = (
-            (temperature is not None and temperature != 1.0)
-            or (top_k is not None and top_k != 0)
-            or (top_p is not None and top_p < 1.0)
-            or (typical_p is not None and typical_p < 1.0)
+                (temperature is not None and temperature != 1.0)
+                or (top_k is not None and top_k != 0)
+                or (top_p is not None and top_p < 1.0)
+                or (typical_p is not None and typical_p < 1.0)
         )
         if has_warpers:
             self.static_warper = static_warper(
@@ -82,9 +82,9 @@ class NextTokenChooser:
 
     @classmethod
     def from_pb(
-        cls,
-        pb: generate_pb2.NextTokenChooserParameters,
-        device: torch.device,
+            cls,
+            pb: generate_pb2.NextTokenChooserParameters,
+            device: torch.device,
     ) -> "NextTokenChooser":
         return NextTokenChooser(
             watermark=pb.watermark,
@@ -113,11 +113,11 @@ class StopSequenceCriteria:
 
 class StoppingCriteria:
     def __init__(
-        self,
-        eos_token_id: int,
-        stop_sequence_criterias: List[StopSequenceCriteria],
-        max_new_tokens: int = 20,
-        ignore_eos_token: bool = False,
+            self,
+            eos_token_id: int,
+            stop_sequence_criterias: List[StopSequenceCriteria],
+            max_new_tokens: int = 20,
+            ignore_eos_token: bool = False,
     ):
         self.eos_token_id = eos_token_id
         self.stop_sequence_criterias = stop_sequence_criterias
@@ -143,9 +143,9 @@ class StoppingCriteria:
 
     @classmethod
     def from_pb(
-        cls,
-        pb: generate_pb2.StoppingCriteriaParameters,
-        tokenizer: PreTrainedTokenizerBase,
+            cls,
+            pb: generate_pb2.StoppingCriteriaParameters,
+            tokenizer: PreTrainedTokenizerBase,
     ) -> "StoppingCriteria":
         stop_sequence_criterias = [
             StopSequenceCriteria(sequence) for sequence in pb.stop_sequences
@@ -160,18 +160,18 @@ class StoppingCriteria:
 
 class HeterogeneousNextTokenChooser:
     def __init__(
-        self,
-        dtype: torch.dtype,
-        device: torch.device,
-        watermark: List[bool],
-        temperature: List[float],
-        repetition_penalty: List[float],
-        top_k: List[int],
-        top_p: List[float],
-        typical_p: List[float],
-        do_sample: List[bool],
-        seeds: List[int],
-        logit_bias: Dict[Tuple[int], float],
+            self,
+            dtype: torch.dtype,
+            device: torch.device,
+            watermark: List[bool],
+            temperature: List[float],
+            repetition_penalty: List[float],
+            top_k: List[int],
+            top_p: List[float],
+            typical_p: List[float],
+            do_sample: List[bool],
+            seeds: List[int],
+            logit_bias: List[Dict[Tuple[int], float]],
     ):
         warpers = []
 
@@ -196,8 +196,14 @@ class HeterogeneousNextTokenChooser:
         )
 
         self.sequence_bias_logits_processor = (
-            SequenceBiasLogitsProcessor(sequence_bias = logit_bias)
-        ) if any([logit_bias[k] != 0.0 for k in logit_bias]) else None
+            HeterogeneousProcessorWrapper({
+                i: SequenceBiasLogitsProcessor(
+bias
+                )
+                for i, bias in enumerate(logit_bias)
+                if any([bias[k] != 0.0 for k in bias])
+            })
+        ) if logit_bias else None
 
         if any([x != 1.0 for x in temperature]):
             do_sample = [
@@ -275,10 +281,10 @@ class HeterogeneousNextTokenChooser:
 
     @classmethod
     def from_pb(
-        cls,
-        pb: List[generate_pb2.NextTokenChooserParameters],
-        dtype: torch.dtype,
-        device: torch.device,
+            cls,
+            pb: List[generate_pb2.NextTokenChooserParameters],
+            dtype: torch.dtype,
+            device: torch.device,
     ) -> "HeterogeneousNextTokenChooser":
         return HeterogeneousNextTokenChooser(
             watermark=[pb_.watermark for pb_ in pb],
@@ -291,6 +297,7 @@ class HeterogeneousNextTokenChooser:
             seeds=[pb_.seed for pb_ in pb],
             device=device,
             dtype=dtype,
+            logit_bias={},
         )
 
 

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -48,10 +48,10 @@ class NextTokenChooser:
         ) if logit_bias and any([logit_bias[k] != 0.0 for k in logit_bias]) else None
 
         has_warpers = (
-                (temperature is not None and temperature != 1.0)
-                or (top_k is not None and top_k != 0)
-                or (top_p is not None and top_p < 1.0)
-                or (typical_p is not None and typical_p < 1.0)
+            (temperature is not None and temperature != 1.0)
+            or (top_k is not None and top_k != 0)
+            or (top_p is not None and top_p < 1.0)
+            or (typical_p is not None and typical_p < 1.0)
         )
         if has_warpers:
             self.static_warper = static_warper(
@@ -82,10 +82,10 @@ class NextTokenChooser:
 
     @classmethod
     def from_pb(
-            cls,
-            pb: generate_pb2.NextTokenChooserParameters,
-            device: torch.device,
-            tokenizer: PreTrainedTokenizerBase,
+        cls,
+        pb: generate_pb2.NextTokenChooserParameters,
+        device: torch.device,
+        tokenizer: PreTrainedTokenizerBase,
     ) -> "NextTokenChooser":
         return NextTokenChooser(
             watermark=pb.watermark,
@@ -116,11 +116,11 @@ class StopSequenceCriteria:
 
 class StoppingCriteria:
     def __init__(
-            self,
-            eos_token_id: int,
-            stop_sequence_criterias: List[StopSequenceCriteria],
-            max_new_tokens: int = 20,
-            ignore_eos_token: bool = False,
+        self,
+        eos_token_id: int,
+        stop_sequence_criterias: List[StopSequenceCriteria],
+        max_new_tokens: int = 20,
+        ignore_eos_token: bool = False,
     ):
         self.eos_token_id = eos_token_id
         self.stop_sequence_criterias = stop_sequence_criterias
@@ -146,9 +146,9 @@ class StoppingCriteria:
 
     @classmethod
     def from_pb(
-            cls,
-            pb: generate_pb2.StoppingCriteriaParameters,
-            tokenizer: PreTrainedTokenizerBase,
+        cls,
+        pb: generate_pb2.StoppingCriteriaParameters,
+        tokenizer: PreTrainedTokenizerBase,
     ) -> "StoppingCriteria":
         stop_sequence_criterias = [
             StopSequenceCriteria(sequence) for sequence in pb.stop_sequences
@@ -163,18 +163,18 @@ class StoppingCriteria:
 
 class HeterogeneousNextTokenChooser:
     def __init__(
-            self,
-            dtype: torch.dtype,
-            device: torch.device,
-            watermark: List[bool],
-            temperature: List[float],
-            repetition_penalty: List[float],
-            top_k: List[int],
-            top_p: List[float],
-            typical_p: List[float],
-            do_sample: List[bool],
-            seeds: List[int],
-            logit_bias: List[Dict[Tuple[int], float]],
+        self,
+        dtype: torch.dtype,
+        device: torch.device,
+        watermark: List[bool],
+        temperature: List[float],
+        repetition_penalty: List[float],
+        top_k: List[int],
+        top_p: List[float],
+        typical_p: List[float],
+        do_sample: List[bool],
+        seeds: List[int],
+        logit_bias: List[Dict[Tuple[int], float]],
     ):
         warpers = []
 
@@ -284,11 +284,11 @@ class HeterogeneousNextTokenChooser:
 
     @classmethod
     def from_pb(
-            cls,
-            pb: List[generate_pb2.NextTokenChooserParameters],
-            dtype: torch.dtype,
-            device: torch.device,
-            tokenizer: PreTrainedTokenizerBase,
+        cls,
+        pb: List[generate_pb2.NextTokenChooserParameters],
+        dtype: torch.dtype,
+        device: torch.device,
+        tokenizer: PreTrainedTokenizerBase,
     ) -> "HeterogeneousNextTokenChooser":
         return HeterogeneousNextTokenChooser(
             watermark=[pb_.watermark for pb_ in pb],


### PR DESCRIPTION
# What does this PR do?

Adds support for sending `logit_bias`'s during token generation using [SequenceBiasLogitsProcessor](https://huggingface.co/docs/transformers/main/en/internal/generation_utils#transformers.SequenceBiasLogitsProcessor).

Fixes #240 

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests) Pull Request section?
- [ ] Did you make sure to update the documentation with your changes.
- [ ] Did you write any new necessary tests?

## Tasks still remaining.

- [ ] Fix `FlashCausalLMBatch.concatenate`

   As we need to tokenize the inputs to `logit_bias` in order to create a `SequenceBiasLogitsProcessor` there needs to be a  tokenizer passed into `NextTokenChooser.from_pb` and `HeterogeneousNextTokenChooser.from_pb` this was no issue everywhere but `FlashCausalLMBatch.concatenate`. 

    I'm looking for feedback on how to resolve this nicely - the obvious solution would be to store a `tokenizer` in `FlashCausalLMBatch` or `HeterogeneousNextTokenChooser` similar to how `device` is selected when concatenating at the moment.

- [ ] Add Python tests

- [ ] Update client

- [ ] Documentation

    Not 100% if this is complete. I've updated the rust openapi schema and added docs to the protobuf files - not sure if this is sufficient.

## Who can review?

@OlivierDehaene