### PR TITLE
Self-generating docs for OpenAPI

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -123,7 +123,7 @@ responses(
 (status = 424, description = "Generation Error", body = ErrorResponse,
 example = json ! ({"error": "Request failed during generation"})),
 (status = 429, description = "Model is overloaded", body = ErrorResponse,
-example = json ! ({"error": "Model çis overloaded"})),
+example = json ! ({"error": "Model is overloaded"})),
 (status = 422, description = "Input validation error", body = ErrorResponse,
 example = json ! ({"error": "Input validation error"})),
 (status = 500, description = "Incomplete generation", body = ErrorResponse,

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -128,6 +128,11 @@ example = json ! ({"error": "Model is overloaded"})),
 example = json ! ({"error": "Input validation error"})),
 (status = 500, description = "Incomplete generation", body = ErrorResponse,
 example = json ! ({"error": "Incomplete generation"})),
+params(("max_input_length" = usize, Path, description = "This is the maximum allowed input 
+length (expressed in number of tokens) for users. The larger this value, the longer prompt
+users can send which can impact the overall memory required to handle the load.
+Please note that some models have a finite range of sequence they can handle."),
+)),
 )
 )]
 #[instrument(

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -129,7 +129,7 @@ example = json ! ({"error": "Input validation error"})),
 (status = 500, description = "Incomplete generation", body = ErrorResponse,
 example = json ! ({"error": "Incomplete generation"})),
 ),
-params(("max_input_length" = usize, Path, description = "This is the maximum allowed input 
+params(("max_input_length" = usize, description = "This is the maximum allowed input 
 length (expressed in number of tokens) for users. The larger this value, the longer prompt
 users can send which can impact the overall memory required to handle the load.
 Please note that some models have a finite range of sequence they can handle.")),

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -123,17 +123,16 @@ responses(
 (status = 424, description = "Generation Error", body = ErrorResponse,
 example = json ! ({"error": "Request failed during generation"})),
 (status = 429, description = "Model is overloaded", body = ErrorResponse,
-example = json ! ({"error": "Model is overloaded"})),
+example = json ! ({"error": "Model çis overloaded"})),
 (status = 422, description = "Input validation error", body = ErrorResponse,
 example = json ! ({"error": "Input validation error"})),
 (status = 500, description = "Incomplete generation", body = ErrorResponse,
 example = json ! ({"error": "Incomplete generation"})),
-params("max_input_length" = usize, Path, description = "This is the maximum allowed input 
+),
+params(("max_input_length" = usize, Path, description = "This is the maximum allowed input 
 length (expressed in number of tokens) for users. The larger this value, the longer prompt
 users can send which can impact the overall memory required to handle the load.
-Please note that some models have a finite range of sequence they can handle."),
-),
-)
+Please note that some models have a finite range of sequence they can handle.")),
 )]
 #[instrument(
 skip_all,

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -128,11 +128,11 @@ example = json ! ({"error": "Model is overloaded"})),
 example = json ! ({"error": "Input validation error"})),
 (status = 500, description = "Incomplete generation", body = ErrorResponse,
 example = json ! ({"error": "Incomplete generation"})),
-params(("max_input_length" = usize, Path, description = "This is the maximum allowed input 
+params("max_input_length" = usize, Path, description = "This is the maximum allowed input 
 length (expressed in number of tokens) for users. The larger this value, the longer prompt
 users can send which can impact the overall memory required to handle the load.
 Please note that some models have a finite range of sequence they can handle."),
-)),
+),
 )
 )]
 #[instrument(


### PR DESCRIPTION
This is an attempt to add self-generating docs by a non-Rust user. I added only one parameter to show how I did it, but I failed horribly.
We are using [utoipa](https://github.com/juhaku/utoipa) to automatically generate the OpenAPI reference from Rust router, I checked utoipa docs & examples but it didn't help. 

e.g. when I serve this example: https://github.com/juhaku/utoipa/blob/master/examples/todo-warp/src/main.rs on my local, params appear perfectly fine which should also happen for TGI’s params above
the code over there: 
```rust
#[utoipa::path(
        delete,
        path = "/todo/{id}",
        responses(
            ...
        ),
        params(
            ("id" = i64, Path, description = "Todo's unique id")
        ),
        security(
            ("api_key" = [])
        )
    )]
```

**Screenshot of intended behavior in swagger:** 

![Screenshot 2023-08-18 at 15 57 44](https://github.com/huggingface/text-generation-inference/assets/53175384/2908a9eb-94ed-468d-8d75-82680402ec76)

Would be nice to get even a second look for this PR. 
