### PR TITLE
feat: Add FT weight-only quantization GEMM CUDA kernel support

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -25,6 +25,7 @@ enum Quantization {
     BitsandbytesNF4,
     BitsandbytesFP4,
     Gptq,
+    Eetq,
 }
 
 impl std::fmt::Display for Quantization {
@@ -42,6 +43,9 @@ impl std::fmt::Display for Quantization {
             }
             Quantization::Gptq => {
                 write!(f, "gptq")
+            }
+            Quantization::Eetq => {
+                write!(f, "eetq")
             }
         }
     }

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,6 +1,7 @@
 include Makefile-flash-att
 include Makefile-flash-att-v2
 include Makefile-vllm
+include Makefile-eetq
 
 unit-tests:
 	pytest -s -vv -m "not private" tests

--- a/server/Makefile-eetq
+++ b/server/Makefile-eetq
@@ -1,0 +1,13 @@
+eetq_commit := 323827dd471458a84e9c840f614e4592b157a4b1
+
+eetq:
+    # Clone eetq
+	pip install packaging
+	git clone https://github.com/NetEase-FuXi/EETQ.git eetq
+
+build-eetq: eetq
+	cd eetq && git fetch && git checkout $(eetq_commit)
+	cd eetq && python setup.py build
+
+install-eetq: build-eetq
+	cd eetq && python setup.py install

--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -17,6 +17,7 @@ class Quantization(str, Enum):
     bitsandbytes_nf4 = "bitsandbytes-nf4"
     bitsandbytes_fp4 = "bitsandbytes-fp4"
     gptq = "gptq"
+    eetq = "eetq"
 
 
 class Dtype(str, Enum):


### PR DESCRIPTION
# What does this PR do?
Add FT weight-only quantization CUDA kernel support. We extracted weight-only GEMM kernel from [FasterTransformer](https://github.com/NVIDIA/FasterTransformer/tree/main/src/fastertransformer/kernels/cutlass_kernels/fpA_intB_gemm), 
and create a [project](https://github.com/NetEase-FuXi/EETQ.git) to use it easily.
- Features
  * Weight-only quantization is easy to use and no additional training required.
  * Work on every model
  * There is almost no loss of quantization accuracy.
  * Compared to bitsandbytes and gptq, the performance is also better.

- Usage
```bash
$ --quantize eetq
```

- Test
Below is our test on 3090. environment: torch=2.01, cuda=11.8, nvidia driver: 525.78.01
prompt=1024, max_new_tokens=50

![benchmark](https://github.com/huggingface/text-generation-inference/assets/30221696/10bc86d2-013a-4a3c-badb-4065684d39ec)

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
