### PR TITLE
Fix a tokenizer issue in decoding generated tokens

### DIFF
--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -641,8 +641,8 @@ class CausalLM(Model):
             if i % self.world_size == self.rank:
                 if stop:
                     # Decode generated tokens
-                    output_text = self.decode(
-                        all_input_ids[-stopping_criteria.current_tokens :, 0]
+                    output_text = self.decode_generated_tokens(
+                        all_input_ids[:, 0], stopping_criteria.current_tokens
                     )
                     # Get seed
                     if isinstance(next_token_chooser.choice, Sampling):

--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -1008,9 +1008,11 @@ class FlashCausalLM(Model):
             if i % self.world_size == self.rank:
                 if stop:
                     # Decode generated tokens
-                    output_text = self.decode(
-                        all_input_ids[-stopping_criteria.current_tokens :]
+                    output_text = self.decode_generated_tokens(
+                        all_input_ids,
+                        stopping_criteria.current_tokens,
                     )
+                    
                     generated_text = GeneratedText(
                         output_text,
                         stopping_criteria.current_tokens,

--- a/server/text_generation_server/models/idefics_causal_lm.py
+++ b/server/text_generation_server/models/idefics_causal_lm.py
@@ -728,8 +728,8 @@ class IdeficsCausalLM(Model):
             if i % self.world_size == self.rank:
                 if stop:
                     # Decode generated tokens
-                    output_text = self.decode(
-                        all_input_ids[-stopping_criteria.current_tokens :, 0]
+                    output_text = self.decode_generated_tokens(
+                        all_input_ids[:, 0], stopping_criteria.current_tokens
                     )
                     # Get seed
                     if isinstance(next_token_chooser.choice, Sampling):

--- a/server/text_generation_server/models/model.py
+++ b/server/text_generation_server/models/model.py
@@ -85,6 +85,21 @@ class Model(ABC):
             return new_text, read_offset, len(all_input_ids)
         else:
             return "", prefix_offset, read_offset
+    
+    def decode_generated_tokens(
+        self,
+        all_input_ids: List[int],
+        num_tokens: int = 0,
+    ) -> str:
+        # Like in `decode_token()`, the prefix text is necessary only to defeat cleanup algorithms in the decode.
+        prefix_text = self.tokenizer.decode(
+            all_input_ids[-num_tokens-1:-num_tokens], skip_special_tokens=False
+        )
+        new_text = self.tokenizer.decode(
+            all_input_ids[-num_tokens-1:], skip_special_tokens=False
+        )
+        new_text = new_text[len(prefix_text):]
+        return new_text
 
     def check_initialized(self):
         uninitialized_parameters = []


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

### TL;DR
Fixes a tokenization issue in `Client.generate()` method which mistakenly removes a blank space at the beginning of the output texts.

### Replication
The concerned issue can be replicated by running code generation with `CodeLlama-7b-Python-hf` model:

```bash
model=codellama/CodeLlama-7b-Python-hf
volume=$PWD/data
docker run --rm --gpus all --shm-size 1g \
    -p 8080:80 -v $volume:/data ghcr.io/huggingface/text-generation-inference:latest \
    --model-id $model --sharded true --num-shard 4
```

Then, with a prompt for code completion, calling `client.generate()` and `client.generate_stream()` result in different outputs:

```python
from text_generation import Client

client = Client("http://127.0.0.1:8080")
prompt = '\n\ndef truncate_number(number: float) -> float:\n    """ Given a positive floating point number, it can be decomposed into\n    and integer part (largest integer smaller than given number) and decimals\n    (leftover part always smaller than 1).\n\n    Return the decimal part of the number.\n    >>> truncate_number(3.5)\n    0.5\n    """\n'

### `client.generate()` method
print(client.generate(prompt=prompt, do_sample=True, top_k=10, temperature=0.1, top_p=0.95, max_new_tokens=10,repetition_penalty=1.05).generated_text)
# output: '  return number - int(number)'

### `client.generate_stream()` method
for response in client.generate_stream(prompt=prompt, do_sample=True, top_k=10, temperature=0.1, top_p=0.95, max_new_tokens=10,repetition_penalty=1.05):
    if not response.token.special:
        print(response.token.text, end="")
# output: '    return number - int(number)'
```

The latter output starts with 4 whitespaces, which matches the indent format in Python so the completed function runs correctly; while the former output starts with only 2 whitespaces. Such indent mismatching is DETRIMENTAL in code generation tasks, especially for indent-aware languages such as Python. The resulting indent error dramatically affects the correctness of `CodeLlama-7b-Python-hf` model on HumanEval (pass@1) from >30% to ~3%.

The root cause of the `client.generate()` case is at Line 1011 in `text-generation-inference/server/text_generation_server/models/flash_causal_lm.py` : 

```python
### text-generation-inference/server/text_generation_server/models/flash_causal_lm.py ###
# Decode generated tokens
output_text = self.decode(
    all_input_ids[-stopping_criteria.current_tokens :]
)
```

The generated tokens are jointly sent to `self.decode()` method, which includes an additional step of removing the prefix space at the first token (in our case this method executes the following `convert_tokens_to_string()` function in `transformers/models/llama/tokenization_llama.py` ):

```python
### transformers/models/llama/tokenization_llama.py ###
def convert_tokens_to_string(self, tokens):
        """Converts a sequence of tokens (string) in a single string."""
        # since we manually add the prefix space, we have to remove it when decoding
        if tokens[0].startswith(SPIECE_UNDERLINE):
            tokens[0] = tokens[0][1:]
        ...
```

Since the generated tokens do not start from the beginning of a sentence, the above space removal is redundant and problematic.

For the `client.generate_stream()` case, generated tokens are printed out one by one, bypassing the aforementioned function, so prefix spaces are retained.

### Solution
To ensure two outputs to be consistent, we add a `self.decode_generated_tokens()` method in `Model` class, which works by including an additional prefix tokenizer for decoding, and then substract it from the output text:

```python
### text-generation-inference/server/text_generation_server/models/model.py ###
def decode_generated_tokens(
        self,
        all_input_ids: List[int],
        num_tokens: int = 0,
    ) -> str:
        # Like in `decode_token()`, the prefix text is necessary only to defeat cleanup algorithms in the decode.
        prefix_text = self.tokenizer.decode(
            all_input_ids[-num_tokens-1:-num_tokens], skip_special_tokens=False
        )
        new_text = self.tokenizer.decode(
            all_input_ids[-num_tokens-1:], skip_special_tokens=False
        )
        new_text = new_text[len(prefix_text):]
        return new_text
```

The modified line in `text-generation-inference/server/text_generation_server/models/flash_causal_lm.py` becomes:

```python
### text-generation-inference/server/text_generation_server/models/flash_causal_lm.py ###
# Decode generated tokens
output_text = self.decode_generated_tokens(
    all_input_ids,
    stopping_criteria.current_tokens,
)
```

So that both generation methods yield the same output. Similar modification is also applied to `causal_lm.py` and `idefics_causal_lm.py` .


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
