### PR TITLE
Install curl to be able to perform more advanced healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,6 +158,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         libssl-dev \
         ca-certificates \
         make \
+        curl \
         && rm -rf /var/lib/apt/lists/*
 
 # Copy conda with PyTorch installed


### PR DESCRIPTION
# What does this PR do?

Install curl within base image, negligible regarding the image volume and will allow to easily perform a better health check. Not sure about the failing github actions though. Should I fix something ?