### PR TITLE
fix discard_names bug in safetensors convertion

### DIFF
--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -186,8 +186,11 @@ def download_weights(
             class_ = getattr(transformers, architecture)
 
             # Name for this varible depends on transformers version.
-            discard_names = getattr(class_, "_tied_weights_keys", [])
-            discard_names.extend(getattr(class_, "_keys_to_ignore_on_load_missing", []))
+            discard_names = []
+            if getattr(class_, "_tied_weights_keys", []):
+                discard_names.extend(getattr(class_, "_tied_weights_keys", []))
+            if getattr(class_, "_keys_to_ignore_on_load_missing", []):
+                discard_names.extend(getattr(class_, "_keys_to_ignore_on_load_missing", []))
 
         except Exception as e:
             discard_names = []

--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -186,11 +186,7 @@ def download_weights(
             class_ = getattr(transformers, architecture)
 
             # Name for this varible depends on transformers version.
-            discard_names = []
-            if getattr(class_, "_tied_weights_keys", []):
-                discard_names.extend(getattr(class_, "_tied_weights_keys", []))
-            if getattr(class_, "_keys_to_ignore_on_load_missing", []):
-                discard_names.extend(getattr(class_, "_keys_to_ignore_on_load_missing", []))
+            discard_names = getattr(class_, "_tied_weights_keys", [])
 
         except Exception as e:
             discard_names = []


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Model Class attributes `_tied_weights_keys`, ` _keys_to_ignore_on_load_missing` can only be `None` or a List. `getattr(class_, "_keys_to_ignore_on_load_missing", [])` will return `None` if `_keys_to_ignore_on_load_missing` is None, and `discard_names.extend(None)` will trigger an exception, even though `_tied_weights_keys`  exists.

## Who can review?

@OlivierDehaene  @Narsil


