### PR TITLE
support local model config file

### DIFF
--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -179,7 +179,10 @@ def download_weights(
             import json
 
 
-            config_filename = hf_hub_download(model_id, revision=revision, filename="config.json")
+            if is_local_model:
+                config_filename = os.path.join(model_id, "config.json")
+            else:
+                config_filename = hf_hub_download(model_id, revision=revision, filename="config.json")
             with open(config_filename, "r") as f:
                 config = json.load(f)
             architecture = config["architectures"][0]


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Support local config file to avoid unexpected `discard_names`, which causes #1057.

In the case of launching local mode without `model.safetensors` file,  the original code will result `discard_names = []` when `hf_hub_download` throws an connection error.
```python
# server/text_generation_server/cli.py
    try:
        import transformers
        import json
    
    
        config_filename = hf_hub_download(model_id, revision=revision, filename="config.json")
        with open(config_filename, "r") as f:
            config = json.load(f)
        architecture = config["architectures"][0]
    
        class_ = getattr(transformers, architecture)
    
        # Name for this varible depends on transformers version.
        discard_names = getattr(class_, "_tied_weights_keys", [])
        discard_names.extend(getattr(class_, "_keys_to_ignore_on_load_missing", []))
    
    except Exception as e:
        discard_names = []
```

The expected `_tied_weights_keys` of OPT-1.3b is `["lm_head.weight"]`, and its tied weight `"model.decoder.embed_tokens.weight"` will be kept in the safetensors conversion. But the above empty `discard_names` will lead to `"lm_head.weight"` being kept and `"model.decoder.embed_tokens.weight"` being discard  in the subsequent method `_remove_duplicate_names`, which causes error #1057.

So add a local mode branch to get the expected `discard_names` like follows. This modification also applies to other models

```python
# server/text_generation_server/cli.py
        if is_local_model:
            config_filename = os.path.join(model_id, "config.json")
        else:
            config_filename = hf_hub_download(model_id, revision=revision, filename="config.json")
```


In addition, when `_tied_weights_keys` or `_keys_to_ignore_on_load_missing` is `None`, the above code will also throw an error unexpectedly. This is fixed in PR #1052 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).   N/A
- [ ] Did you write any new necessary tests?  N/A


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil

