### PR TITLE
Fix shared weights load bug and T5 loading

### DIFF
--- a/server/text_generation_server/models/t5.py
+++ b/server/text_generation_server/models/t5.py
@@ -63,6 +63,7 @@ class T5Sharded(Seq2SeqLM):
                 "shared.weight": [
                     "encoder.embed_tokens.weight",
                     "decoder.embed_tokens.weight",
+                    "lm_head.weight",
                 ]
             },
         )

--- a/server/text_generation_server/utils/weights.py
+++ b/server/text_generation_server/utils/weights.py
@@ -45,9 +45,9 @@ class Weights:
     def get_filename(self, tensor_name: str) -> (str, str):
         filename = self.routing.get(tensor_name, None)
         if filename is None:
-            aliases = self.aliases.get(tensor_name, [])
-            for alias in aliases:
-                filename = self.routing.get(alias, None)
+            for alias, tensor_list in self.aliases.items():
+                if tensor_name in tensor_list:
+                    filename = self.routing.get(alias, None)
                 if filename is not None:
                     return str(filename), alias
             raise RuntimeError(f"weight {tensor_name} does not exist")


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #1038 

The error `RuntimeError: weight lm_head.weight does not exist`  was caused by two factors:

1. Missing a tied weight `"lm_head.weight"` in the T5 aliases dict
```python
# server/text_generation_server/models/t5.py
aliases={
    "shared.weight": [
        "encoder.embed_tokens.weight",
        "decoder.embed_tokens.weight",
        "lm_head.weight",
    ]
},
```
2. Wrong logic of  the method `Weights.get_filename`
 
According to the above aliases dict,  `Weights.get_filename` method is expected to receive a discard name `"lm_head.weight"` and return its alias name `"shared.weight"` and filename, but the following code wouldn't achieve this. 

```python
# server/text_generation_server/utils/weights.py
    def get_filename(self, tensor_name: str) -> (str, str):
        filename = self.routing.get(tensor_name, None)
        if filename is None:
            aliases = self.aliases.get(tensor_name, [])
            for alias in aliases:
                filename = self.routing.get(alias, None)
                if filename is not None:
                    return str(filename), alias
            raise RuntimeError(f"weight {tensor_name} does not exist")
        return str(filename), tensor_name
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
@Narsil @anindya-saha 