### PR TITLE
Add ignore_eos_token to HTTP interface

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -138,6 +138,9 @@ pub(crate) struct GenerateParameters {
     #[serde(default)]
     #[schema(exclusive_minimum = 0, nullable = true, default = "null", example = 5)]
     pub top_n_tokens: Option<u32>,
+    #[serde(default)]
+    #[schema(default = "false")]
+    pub ignore_eos_token: bool
 }
 
 fn default_max_new_tokens() -> Option<u32> {
@@ -162,6 +165,7 @@ fn default_parameters() -> GenerateParameters {
         decoder_input_details: false,
         seed: None,
         top_n_tokens: None,
+        ignore_eos_token: false,
     }
 }
 

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -156,6 +156,7 @@ impl Validation {
             watermark,
             decoder_input_details,
             top_n_tokens,
+            ignore_eos_token,
             ..
         } = request.parameters;
 
@@ -274,7 +275,7 @@ impl Validation {
         let stopping_parameters = StoppingCriteriaParameters {
             max_new_tokens,
             stop_sequences,
-            ignore_eos_token: false,
+            ignore_eos_token: ignore_eos_token,
         };
 
         metrics::histogram!("tgi_request_max_new_tokens", max_new_tokens as f64);

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -275,7 +275,7 @@ impl Validation {
         let stopping_parameters = StoppingCriteriaParameters {
             max_new_tokens,
             stop_sequences,
-            ignore_eos_token: ignore_eos_token,
+            ignore_eos_token,
         };
 
         metrics::histogram!("tgi_request_max_new_tokens", max_new_tokens as f64);


### PR DESCRIPTION
# What does this PR do?

Adds `ignore_eos_token` in `parameters` in the HTTP interface with the default set to false.
This can be useful for benchmarking situations or generally debugging/forcing longer generations.
This is already available in the gRPC interface

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Any contributor
