### PR TITLE
Add support for other hardware accelerators

### DIFF
--- a/server/text_generation_server/cache.py
+++ b/server/text_generation_server/cache.py
@@ -4,6 +4,8 @@ from typing import Dict, Optional, TypeVar
 
 from text_generation_server.models.types import Batch
 
+from text_generation_server.utils import is_torch_npu_available
+
 B = TypeVar("B", bound=Batch)
 
 
@@ -24,6 +26,8 @@ class Cache:
             del batch
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+        if is_torch_npu_available():
+            torch.npu.empty_cache()
 
     def clear(self):
         keys = list(self.cache.keys())

--- a/server/text_generation_server/interceptor.py
+++ b/server/text_generation_server/interceptor.py
@@ -6,6 +6,7 @@ from grpc_status import rpc_status
 from grpc_interceptor.server import AsyncServerInterceptor
 from loguru import logger
 from typing import Callable, Any
+from text_generation_server.utils import is_torch_npu_available
 
 
 class ExceptionInterceptor(AsyncServerInterceptor):
@@ -25,6 +26,8 @@ class ExceptionInterceptor(AsyncServerInterceptor):
 
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+            if is_torch_npu_available():
+                torch.npu.empty_cache()
 
             await context.abort_with_status(
                 rpc_status.to_status(

--- a/server/text_generation_server/models/bloom.py
+++ b/server/text_generation_server/models/bloom.py
@@ -19,6 +19,7 @@ from text_generation_server.utils import (
     initialize_torch_distributed,
     weight_files,
     Weights,
+    is_torch_npu_available,
 )
 
 
@@ -48,6 +49,9 @@ class BLOOMSharded(CausalLM):
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():
             device = torch.device(f"cuda:{rank}")
+            dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device(f"npu:{rank}")
             dtype = torch.float16 if dtype is None else dtype
         else:
             device = torch.device("cpu")

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -16,7 +16,12 @@ from text_generation_server.models.types import (
     TopTokens,
 )
 from text_generation_server.pb import generate_pb2
-from text_generation_server.utils import NextTokenChooser, StoppingCriteria, Sampling
+from text_generation_server.utils import (
+    NextTokenChooser,
+    StoppingCriteria,
+    Sampling,
+    is_torch_npu_available,
+)
 
 tracer = trace.get_tracer(__name__)
 
@@ -487,6 +492,9 @@ class CausalLM(Model):
         if torch.cuda.is_available():
             device = torch.device("cuda")
             dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device("npu")
+            dtype = torch.float16 if dtype is None else dtype
         else:
             if quantize:
                 raise ValueError("quantization is not available on CPU")
@@ -513,6 +521,8 @@ class CausalLM(Model):
         )
         if torch.cuda.is_available() and torch.cuda.device_count() == 1:
             model = model.cuda()
+        elif is_torch_npu_available():
+            model = model.npu()
 
         if tokenizer.pad_token_id is None:
             if model.config.pad_token_id is not None:

--- a/server/text_generation_server/models/galactica.py
+++ b/server/text_generation_server/models/galactica.py
@@ -19,6 +19,7 @@ from text_generation_server.utils import (
     initialize_torch_distributed,
     weight_files,
     Weights,
+    is_torch_npu_available,
 )
 
 # CREDIT: Papers with code => https://github.com/paperswithcode/galai/blob/main/galai/utils.py
@@ -171,6 +172,9 @@ class GalacticaSharded(CausalLM):
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():
             device = torch.device(f"cuda:{rank}")
+            dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device(f"npu:{rank}")
             dtype = torch.float16 if dtype is None else dtype
         else:
             device = torch.device("cpu")

--- a/server/text_generation_server/models/gpt_neox.py
+++ b/server/text_generation_server/models/gpt_neox.py
@@ -15,6 +15,7 @@ from text_generation_server.utils import (
     initialize_torch_distributed,
     weight_files,
     Weights,
+    is_torch_npu_available,
 )
 
 
@@ -30,6 +31,9 @@ class GPTNeoxSharded(CausalLM):
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():
             device = torch.device(f"cuda:{rank}")
+            dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device(f"npu:{rank}")
             dtype = torch.float16 if dtype is None else dtype
         else:
             device = torch.device("cpu")

--- a/server/text_generation_server/models/idefics.py
+++ b/server/text_generation_server/models/idefics.py
@@ -22,6 +22,7 @@ from text_generation_server.utils import (
     initialize_torch_distributed,
     weight_files,
     Weights,
+    is_torch_npu_available,
 )
 
 
@@ -39,6 +40,9 @@ class IDEFICSSharded(IdeficsCausalLM):
             device = torch.device(f"cuda:{rank}")
             # 9b seems to work correctly enough in float16, but 80b seems
             # to be really saturating for f16.
+            dtype = torch.bfloat16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device(f"npu:{rank}")
             dtype = torch.bfloat16 if dtype is None else dtype
         else:
             device = torch.device("cpu")

--- a/server/text_generation_server/models/mpt.py
+++ b/server/text_generation_server/models/mpt.py
@@ -18,6 +18,7 @@ from text_generation_server.utils import (
     initialize_torch_distributed,
     weight_files,
     Weights,
+    is_torch_npu_available,
 )
 
 tracer = trace.get_tracer(__name__)
@@ -49,6 +50,9 @@ class MPTSharded(CausalLM):
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():
             device = torch.device(f"cuda:{rank}")
+            dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device(f"npu:{rank}")
             dtype = torch.float16 if dtype is None else dtype
         else:
             device = torch.device("cpu")

--- a/server/text_generation_server/models/opt.py
+++ b/server/text_generation_server/models/opt.py
@@ -13,6 +13,7 @@ from text_generation_server.utils import (
     initialize_torch_distributed,
     weight_files,
     Weights,
+    is_torch_npu_available,
 )
 
 
@@ -28,6 +29,9 @@ class OPTSharded(CausalLM):
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():
             device = torch.device(f"cuda:{rank}")
+            dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device(f"npu:{rank}")
             dtype = torch.float16 if dtype is None else dtype
         else:
             device = torch.device("cpu")

--- a/server/text_generation_server/models/rw.py
+++ b/server/text_generation_server/models/rw.py
@@ -4,6 +4,7 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from typing import List, Optional, Tuple
 
 from text_generation_server.models import CausalLM
+from text_generation_server.utils import is_torch_npu_available
 
 
 class RW(CausalLM):
@@ -17,6 +18,9 @@ class RW(CausalLM):
     ):
         if torch.cuda.is_available():
             device = torch.device("cuda")
+            dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device("npu")
             dtype = torch.float16 if dtype is None else dtype
         else:
             if quantize:
@@ -44,6 +48,8 @@ class RW(CausalLM):
         )
         if torch.cuda.is_available() and torch.cuda.device_count() == 1:
             model = model.cuda()
+        elif is_torch_npu_available():
+            model = model.npu()
 
         if tokenizer.pad_token_id is None:
             if model.config.pad_token_id is not None:

--- a/server/text_generation_server/models/santacoder.py
+++ b/server/text_generation_server/models/santacoder.py
@@ -5,6 +5,7 @@ from typing import Optional, List
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
 from text_generation_server.models import CausalLM
+from text_generation_server.utils import is_torch_npu_available
 
 FIM_PREFIX = "<fim-prefix>"
 FIM_MIDDLE = "<fim-middle>"
@@ -24,6 +25,9 @@ class SantaCoder(CausalLM):
     ):
         if torch.cuda.is_available():
             device = torch.device("cuda")
+            dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device("npu")
             dtype = torch.float16 if dtype is None else dtype
         else:
             if quantize:

--- a/server/text_generation_server/models/seq2seq_lm.py
+++ b/server/text_generation_server/models/seq2seq_lm.py
@@ -15,7 +15,12 @@ from text_generation_server.models.types import (
     TopTokens,
 )
 from text_generation_server.pb import generate_pb2
-from text_generation_server.utils import NextTokenChooser, StoppingCriteria, Sampling
+from text_generation_server.utils import (
+    NextTokenChooser,
+    StoppingCriteria,
+    Sampling,
+    is_torch_npu_available,
+)
 
 tracer = trace.get_tracer(__name__)
 
@@ -536,6 +541,9 @@ class Seq2SeqLM(Model):
         if torch.cuda.is_available():
             device = torch.device("cuda")
             dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device("npu")
+            dtype = torch.float16 if dtype is None else dtype
         else:
             if quantize:
                 raise ValueError("quantization is not available on CPU")
@@ -555,6 +563,8 @@ class Seq2SeqLM(Model):
         )
         if torch.cuda.is_available() and torch.cuda.device_count() == 1:
             model = model.cuda()
+        elif is_torch_npu_available():
+            model = model.npu()
 
         tokenizer = AutoTokenizer.from_pretrained(
             model_id,

--- a/server/text_generation_server/models/t5.py
+++ b/server/text_generation_server/models/t5.py
@@ -16,6 +16,7 @@ from text_generation_server.utils import (
     initialize_torch_distributed,
     weight_files,
     Weights,
+    is_torch_npu_available,
 )
 
 
@@ -31,6 +32,9 @@ class T5Sharded(Seq2SeqLM):
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():
             device = torch.device(f"cuda:{rank}")
+            dtype = torch.float16 if dtype is None else dtype
+        elif is_torch_npu_available():
+            device = torch.device(f"npu:{rank}")
             dtype = torch.float16 if dtype is None else dtype
         else:
             device = torch.device("cpu")

--- a/server/text_generation_server/utils/__init__.py
+++ b/server/text_generation_server/utils/__init__.py
@@ -19,6 +19,7 @@ from text_generation_server.utils.tokens import (
     Sampling,
     Greedy,
 )
+from text_generation_server.utils.import_utils import is_torch_npu_available
 
 __all__ = [
     "convert_file",
@@ -39,4 +40,5 @@ __all__ = [
     "StopSequenceCriteria",
     "FinishReason",
     "Weights",
+    "is_torch_npu_available",
 ]

--- a/server/text_generation_server/utils/import_utils.py
+++ b/server/text_generation_server/utils/import_utils.py
@@ -1,0 +1,18 @@
+import importlib.util
+
+def is_torch_npu_available(check_device=False):
+    "Checks if `torch_npu` is installed and potentially if a NPU is in the environment"
+    if importlib.util.find_spec("torch_npu") is None:
+        return False
+
+    import torch
+    import torch_npu
+
+    if check_device:
+        try:
+            # Will raise a RuntimeError if no NPU is found
+            _ = torch.npu.device_count()
+            return torch.npu.is_available()
+        except RuntimeError:
+            return False
+    return hasattr(torch, "npu") and torch.npu.is_available()


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Add support for other hardwares, such as Ascend NPU accelerator, while maintaining the original code logic and only adding a new hardware judgment branch.

```diff
         if torch.cuda.is_available():
             device = torch.device(f"cuda:{rank}")
             dtype = torch.float16 if dtype is None else dtype
+       elif is_torch_npu_available():
+           device = torch.device(f"npu:{rank}")
+           dtype = torch.float16 if dtype is None else dtype
         else:
             device = torch.device("cpu")
             dtype = torch.float32 if dtype is None else dtype
```
The initialization of the new hardware is placed in `server/text_generation_server/utils/import_utils.py` like `transformers` project.

```python
import importlib.util

def is_torch_npu_available(check_device=False):
    "Checks if `torch_npu` is installed and potentially if a NPU is in the environment"
    if importlib.util.find_spec("torch_npu") is None:
        return False

    import torch
    import torch_npu

    if check_device:
        try:
            # Will raise a RuntimeError if no NPU is found
            _ = torch.npu.device_count()
            return torch.npu.is_available()
        except RuntimeError:
            return False
    return hasattr(torch, "npu") and torch.npu.is_available()
```

[Ascend NPU](https://www.hiascend.com/en/) is an AI processor that support AI frameworks like PyTorch, TensorFlow, which has already integrated by [transformers](https://github.com/huggingface/transformers/pull/24879/commits/d4bb8f7995bc06144eaea727cb9d5056a17975d3), [accelerate](https://github.com/huggingface/accelerate/commit/c33adecc9f92808cbaeb0d34928e52e34180f964), [deepspeed](https://github.com/microsoft/DeepSpeed/commit/23a11a39510e2aefb48236e3d2672a7dcbfc42a3) and other popular LLM related software and tools.

## Use Cases

The models we have validated include Baichuan, Bloom, T5, Galactica, Llama2, OPT, Starcoder, Vicuna.  The actual supported models will be more, as the NPU has already been integrated into the `transformers`

The NPU hardware environment is as follows:
```shell
+------------------------------------------------------------------------------------------------+
| npu-smi 23.0.rc2                 Version: 23.0.rc2                                             |
+---------------------------+---------------+----------------------------------------------------+
| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
| Chip                      | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
+===========================+===============+====================================================+
| 0     910B1               | OK            | 89.2        46                0    / 0             |
| 0                         | 0000:C1:00.0  | 0           0    / 0          26723/ 65536         |
+===========================+===============+====================================================+
| 1     910B1               | OK            | 93.3        50                0    / 0             |
| 0                         | 0000:01:00.0  | 0           0    / 0          4329 / 65536         |
+===========================+===============+====================================================+
| 2     910B1               | OK            | 87.0        48                0    / 0             |
| 0                         | 0000:C2:00.0  | 0           0    / 0          4330 / 65536         |
+===========================+===============+====================================================+
| 3     910B1               | OK            | 100.9       49                0    / 0             |
| 0                         | 0000:02:00.0  | 0           0    / 0          4329 / 65536         |
+===========================+===============+====================================================+
+---------------------------+---------------+----------------------------------------------------+
| NPU     Chip              | Process id    | Process name             | Process memory(MB)      |
+===========================+===============+====================================================+
| 0       0                 | 2902853       | text-generation          | 22420                   |
+===========================+===============+====================================================+
| No running processes found in NPU 1                                                            |
+===========================+===============+====================================================+
| No running processes found in NPU 2                                                            |
+===========================+===============+====================================================+
| No running processes found in NPU 3                                                            |
+===========================+===============+====================================================+
```

### Example of Baichuan2-7B-Chat

launching a model server
```shell
text-generation-launcher --model-id /data/models/Baichuan2-7B-Chat/ --max-input-length 128 --port 8081 --trust-remote-code
```
log info

```log
2023-10-10T01:24:12.945445Z  INFO text_generation_launcher: Args { model_id: "/data/models/Baichuan2-7B-Chat/", revision: None, validation_workers: 2, sharded: None, num_shard: None, quantize: None, dtype: None, trust_remote_code: true, max_concurrent_requests: 128, max_best_of: 2, max_stop_sequences: 4, max_top_n_tokens: 5, max_input_length: 128, max_total_tokens: 2048, waiting_served_ratio: 1.2, max_batch_prefill_tokens: 4096, max_batch_total_tokens: None, max_waiting_tokens: 20, hostname: "ascend-2", port: 8081, shard_uds_path: "/tmp/text-generation-server", master_addr: "localhost", master_port: 29500, huggingface_hub_cache: None, weights_cache_override: None, disable_custom_kernels: false, cuda_memory_fraction: 1.0, rope_scaling: None, rope_factor: None, json_output: false, otlp_endpoint: None, cors_allow_origin: [], watermark_gamma: None, watermark_delta: None, ngrok: false, ngrok_authtoken: None, ngrok_edge: None, env: false }
2023-10-10T01:24:12.945499Z  WARN text_generation_launcher: `trust_remote_code` is set. Trusting that model `/data/models/Baichuan2-7B-Chat/` do not contain malicious code.
2023-10-10T01:24:12.945632Z  INFO download: text_generation_launcher: Starting download process.
2023-10-10T01:24:15.834308Z  INFO text_generation_launcher: Files are already present on the host. Skipping download.

2023-10-10T01:24:16.352181Z  INFO download: text_generation_launcher: Successfully downloaded weights.
2023-10-10T01:24:16.352443Z  INFO shard-manager: text_generation_launcher: Starting shard rank=0
2023-10-10T01:24:19.411855Z  WARN text_generation_launcher: We're not using custom kernels.

2023-10-10T01:24:19.417047Z  WARN text_generation_launcher: Could not import Flash Attention enabled models: No module named 'vllm_cache_ops'

2023-10-10T01:24:19.419766Z  WARN text_generation_launcher: Could not import Mistral model: No module named 'dropout_layer_norm'

2023-10-10T01:24:26.359116Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-10-10T01:28:36.507459Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-10-10T01:28:46.513610Z  INFO shard-manager: text_generation_launcher: Waiting for shard to be ready... rank=0
2023-10-10T01:28:47.324267Z  INFO text_generation_launcher: Server started at unix:///tmp/text-generation-server-0

2023-10-10T01:28:47.414188Z  INFO shard-manager: text_generation_launcher: Shard ready in 271.060993266s rank=0
2023-10-10T01:28:47.500971Z  INFO text_generation_launcher: Starting Webserver
2023-10-10T01:28:47.521717Z  WARN text_generation_router: router/src/main.rs:166: Could not find a fast tokenizer implementation for /data/models/Baichuan2-7B-Chat/
2023-10-10T01:28:47.521768Z  WARN text_generation_router: router/src/main.rs:169: Rust input length validation and truncation is disabled
2023-10-10T01:28:47.521774Z  WARN text_generation_router: router/src/main.rs:194: no pipeline tag found for model /data/models/Baichuan2-7B-Chat/
2023-10-10T01:28:47.582463Z  INFO text_generation_router: router/src/main.rs:213: Warming up model
2023-10-10T01:29:20.191046Z  WARN text_generation_router: router/src/main.rs:224: Model does not support automatic max batch total tokens
2023-10-10T01:29:20.191073Z  INFO text_generation_router: router/src/main.rs:246: Setting max batch total tokens to 16000
2023-10-10T01:29:20.191078Z  INFO text_generation_router: router/src/main.rs:247: Connected
2023-10-10T01:29:20.191085Z  WARN text_generation_router: router/src/main.rs:252: Invalid hostname, defaulting to 0.0.0.0
```

request
```shell
curl 127.0.0.1:8081/generate \
    -X POST \
    -d '{"inputs":"role: user, content: 解释一下“温故而知新”","parameters":{"max_new_tokens":50}}' \
    -H 'Content-Type: application/json'
```

response
```shell
{"generated_text":"这句话的含义\n\n\"温故而知新\"这句话出自《论语·为政》，是孔子的一句名言。它的意思是通过回顾和复习过去的知识，可以发现新的知识和道理。这句话强调了学习和成长的过程，即不断地回顾和总结过去的"}
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
@Narsil