### PR TITLE
Fix: Replace view() with reshape() in neox_modeling.py to resolve RuntimeError

### DIFF
--- a/server/text_generation_server/models/custom_modeling/neox_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/neox_modeling.py
@@ -283,10 +283,10 @@ class GPTNeoXAttention(nn.Module):
         batch_size, num_attention_heads, query_length, attn_head_size = query.size()
         key_length = key.size(-2)
 
-        query = query.view(
+        query = query.reshape(
             batch_size * num_attention_heads, query_length, attn_head_size
         )
-        key = key.view(batch_size * num_attention_heads, key_length, attn_head_size)
+        key = key.reshape(batch_size * num_attention_heads, key_length, attn_head_size)
         attn_scores = torch.zeros(
             1,
             dtype=query.dtype,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

I've noticed an issue in codebase, specifically in the file `text-generation-inference/server/text_generation_server/models/custom_modeling/neox_modeling.py`.  `view()` function function is causing a RuntimeError.

Cause of the issue:

The `view()` function in PyTorch can only be used on contiguous tensors, where all the elements are laid out sequentially in memory. However, operations like `transpose()`, `permute()`, and others can cause a tensor to become non-contiguous. When `view()` is used on such a tensor, it throws a RuntimeError because it cannot reorder the data in memory (Read here for more detail-https://github.com/pytorch/pytorch/issues/84618). In short, view() is causing RuntimeError because it’s being used on tensor that isn’t contiguous.

Solution/Fix:

Here's the fix. Instead of using `view()`, we should use `reshape()`. The `reshape()` function is a bit more flexible than `view()` as it can handle both contiguous and non-contiguous tensors (Read here for more detail-https://stackoverflow.com/questions/49643225/whats-the-difference-between-reshape-and-view-in-pytorch).

So, line 286 to 289, instead of:

```python
query = query.view(
            batch_size * num_attention_heads, query_length, attn_head_size
        )
key = key.view(batch_size * num_attention_heads, key_length, attn_head_size)

```

We should have:

```python
query = query.reshape(
            batch_size * num_attention_heads, query_length, attn_head_size
        )
key = key.reshape(batch_size * num_attention_heads, key_length, attn_head_size)

```

This should solve the issue. I've tested it on my local setup and everything seems to work fine. I've made a pull request with this change. Could you take a look and approve this pr.


## Who can review?
Thanks so much for your time. I really appreciate the work everyone is doing on this project and I'm glad to contribute.
@Narsil or @OlivierDehaene or any other member can you please approve this PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @




 -->
