### PR TITLE
fix: Allow top_p == 1.0 in the Python client

### DIFF
--- a/clients/python/tests/test_types.py
+++ b/clients/python/tests/test_types.py
@@ -50,7 +50,7 @@ def test_parameters_validation():
     with pytest.raises(ValidationError):
         Parameters(top_p=-1)
     with pytest.raises(ValidationError):
-        Parameters(top_p=1)
+        Parameters(top_p=1.01)
 
     # Test truncate
     Parameters(truncate=1)

--- a/clients/python/text_generation/types.py
+++ b/clients/python/text_generation/types.py
@@ -87,8 +87,8 @@ class Parameters(BaseModel):
 
     @validator("top_p")
     def valid_top_p(cls, v):
-        if v is not None and (v <= 0 or v >= 1.0):
-            raise ValidationError("`top_p` must be > 0.0 and < 1.0")
+        if v is not None and (v <= 0 or v > 1.0):
+            raise ValidationError("`top_p` must be > 0.0 and <= 1.0")
         return v
 
     @validator("truncate")


### PR DESCRIPTION
# What does this PR do?

This PR fixes the validation logic in the Python client (`text_generation`), so that it allows `top_p` equal to 1.

`top_p` can be equal to 1 and the TGI server will accept that. 
References:
- [server validation code](https://github.com/huggingface/text-generation-inference/blob/3af1a1140141245c20df20a787831ec71b124eae/router/src/lib.rs#L89-L96)
- [test for that](https://github.com/huggingface/text-generation-inference/blob/3af1a1140141245c20df20a787831ec71b124eae/clients/python/tests/test_types.py#L52-L53)
- [usage](https://github.com/huggingface/text-generation-inference/blob/3af1a1140141245c20df20a787831ec71b124eae/router/src/health.rs#L41)

Also, the [documentation](https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig.top_p) mentions that `1.0` is default value for that param.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

@OlivierDehaene (here's your [PR](https://github.com/huggingface/text-generation-inference/pull/118) that made `top_p==1` invalid, but there was no context, so if that was done on purpose, I'm curious to hear what the reason was, thanks!)
