### PR TITLE
Improvement: Update Dockerfile with explicit Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -226,5 +226,5 @@ ENTRYPOINT ["./entrypoint.sh"]
 # Final image
 FROM base
 
-ENTRYPOINT ["text-generation-launcher"]
+ENTRYPOINT ["/usr/local/bin/text-generation-launcher"]
 CMD ["--json-output"]


### PR DESCRIPTION
We use an explicit entrypoint to avoid confusion when we mount a home folder into our docker container that has another binary of the text-generation-launcher in its $PATH.

# What does this PR do?


A tiny change to the Dockerfile would have saved me hours of debugging today. Mounting your home folder into the docker container may change the PATH variable and offer some random version of the text-generation-launcher instead of the intended one. I think using an explicit binary is better.




## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

