### PR TITLE
DRAFT: Custom logits processors

### DIFF
--- a/proto/generate.proto
+++ b/proto/generate.proto
@@ -50,6 +50,13 @@ message ClearCacheRequest {
 /// Empty response
 message ClearCacheResponse {}
 
+message LogitsProcessorParameters {
+    // The name of the processor to apply
+    string name = 1;
+    // The parameters to pass to the processor
+    repeated string parameters = 2;
+}
+
 message NextTokenChooserParameters {
     /// exponential scaling output probability distribution
     float temperature = 1;
@@ -67,6 +74,8 @@ message NextTokenChooserParameters {
     float repetition_penalty = 7;
     /// token watermarking using "A Watermark for Large Language Models"
     bool watermark = 8;
+    /// Optional Logits Processors definitions
+    repeated LogitsProcessorParameters logits_processors = 9;
 }
 
 message StoppingCriteriaParameters {

--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -125,6 +125,7 @@ impl Client {
                     seed: 0,
                     repetition_penalty: 1.2,
                     watermark: true,
+                    logits_processors: vec![],
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {
                     max_new_tokens: max_total_tokens - truncate,

--- a/router/src/health.rs
+++ b/router/src/health.rs
@@ -44,6 +44,7 @@ impl Health {
                     seed: 0,
                     repetition_penalty: 1.0,
                     watermark: false,
+                    logits_processors: vec![],
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {
                     max_new_tokens: 1,

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -279,6 +279,7 @@ impl Validation {
             do_sample,
             seed,
             watermark,
+            logits_processors: vec![],
         };
         let stopping_parameters = StoppingCriteriaParameters {
             max_new_tokens,

--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -4,7 +4,7 @@ import typer
 
 from pathlib import Path
 from loguru import logger
-from typing import Optional
+from typing import List, Optional
 from enum import Enum
 from huggingface_hub import hf_hub_download
 
@@ -38,6 +38,7 @@ def serve(
     logger_level: str = "INFO",
     json_output: bool = False,
     otlp_endpoint: Optional[str] = None,
+    custom_modules: Optional[List[str]] = None,
 ):
     if sharded:
         assert (
@@ -64,6 +65,14 @@ def serve(
         backtrace=True,
         diagnose=False,
     )
+
+    # Import custom modules. This can be used for Custom Logits Processors,
+    # in which these modules CustomLogitsProcessorsManager.register_factory() in their __init__.py,
+    # registering themselves for custom logits processing.
+    from importlib import import_module
+    if custom_modules:
+        for custom_module in custom_modules:
+            import_module(custom_module)
 
     # Import here after the logger is added to log potential import exceptions
     from text_generation_server import server

--- a/server/text_generation_server/models/galactica.py
+++ b/server/text_generation_server/models/galactica.py
@@ -92,7 +92,7 @@ class GalacticaCausalLMBatch(CausalLMBatch):
             requests_idx_mapping[r.id] = i
             # Add escape_custom_split_sequence to the CausalLMBatch logic
             inputs.append(escape_custom_split_sequence(r.inputs))
-            next_token_choosers.append(NextTokenChooser.from_pb(r.parameters, device))
+            next_token_choosers.append(NextTokenChooser.from_pb(r.parameters, device, tokenizer))
             stopping_criteria = StoppingCriteria.from_pb(
                 r.stopping_parameters, tokenizer
             )

--- a/server/text_generation_server/utils/custom_logits_processors.py
+++ b/server/text_generation_server/utils/custom_logits_processors.py
@@ -1,0 +1,29 @@
+from typing import Dict, Iterable
+from transformers import PreTrainedTokenizerBase, LogitsWarper
+import abc
+
+
+class CustomLogitsWarperFactory(abc.ABC):
+    def __init__(self, name):
+        self.name = name
+
+    @abc.abstractmethod
+    def create_warper(self, tokenizer: PreTrainedTokenizerBase, params: Iterable[str]) -> LogitsWarper:
+        raise NotImplementedError
+
+
+class CustomLogitsProcessorsManager:
+    processors: Dict[str, CustomLogitsWarperFactory] = {}
+    
+    @classmethod
+    def register_factory(cls, factory: CustomLogitsWarperFactory):
+        """Register a factory for a custom warper. This should be called by library developers in the __init__.py of their custom warper module,
+        and the module should be included in the custom_modules command line argument of the text-generation-server CLI."""
+        cls.processors[factory.name] = factory
+
+    @classmethod
+    def create_warper(cls, name: str, tokenizer: PreTrainedTokenizerBase, params: Iterable[str]) -> LogitsWarper:
+        """Create a custom warper by name."""
+        if name not in cls.processors:
+            raise ValueError(f"Unknown warper {name}. Known warpers: {', '.join(cls.processors.keys())}")
+        return cls.processors[name].create_warper(tokenizer, params)


### PR DESCRIPTION
# What does this PR do?

This PR is meant for discussion purposes, around the idea to add custom logits processors, discussed here:
https://github.com/huggingface/text-generation-inference/issues/1269
It is not fully implemented yet, but the interfaces are there, and the design discussion can be held.

The idea is, how can we add custom logits processing code, allowing individual generation requests to control them, without injecting new dependencies to the `text-generation-inference` server.

Example use case:
The [lm-format-enforcer](https://github.com/noamgat/lm-format-enforcer) library supports JSON Schema and Regex decoding using logits processing. Can we use the `text-generation-inference` server to decode different JSON schemas and regexes for different requests?

This PR proposes the following solution:
- The `NextTokenChooserParameters` message will contain optional `LogitsProcessorParameters` objects, each containing the name of the processor, and a list of strings as its parameters (staying as generic as possible to make the grpc layer simple).
- The server will have a central repository of named "logits processor factories" that can receive these parameters and create a request-specific logits warper
- The server will have a command line module loader option, to enable loading of these modules, that will register themselves in the central repository when they loaded.

This will allow external libraries to register logits processors, that will be used when requests that mention them are given.

Example flow:
- Server is loaded with ```--custom_modules=lmformatenforcer.integrations.text_generation_inference``` flag
- The module is loaded, and its `__init__.py` code calls `CustomLogitsProcessorsManager.register_factory(JsonSchemaFactory)`
- A request arrives, with `name=jsonschema, parameters=["<str of json schema>"]` in the logits parameters
- The `NextTokenChooser` constructor finds the factory in the central repository, and creates a logits warper for decoding the specific JSON schema
- After every timestep, the warper is called, putting `-inf` in the logits of the tokens that would violate the json schema
- The result is a valid json string that conforms to the schema

What do you think of this design? You can look at the branch comparison for most of the key ideas. Can I go ahead and continue the full implementation?


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
