### PR TITLE
Updating vllm to use cuda 12.1 and pytorch 2.1

### DIFF
--- a/server/Makefile-vllm
+++ b/server/Makefile-vllm
@@ -1,4 +1,4 @@
-vllm_commit := f8a1e39fae05ca610be8d5a78be9d40f5274e5fc
+vllm_commit := c5f7740d89737744438e08c26da1d4fbadcb3893
 
 vllm:
     # Clone vllm


### PR DESCRIPTION
# What does this PR do?

This PR updates the commit for the vllm project to the latest release which supports cuda 12.1 and pytorch 2.1

Fixes # (issue)
Mixing cuda versions after running `cd server && make install-flash-attention-v2 && make install-vllm` is fixed by upgrading vllm to the latest release

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

This is discussed in #1284. An huge issue is that xformers wants transformers>=4.34.0 and text-generation-server needs tokenizer<0.14.0.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
