### PR TITLE
Fix incorrect use of bias in awq

### DIFF
--- a/server/text_generation_server/utils/awq/quantize/qmodule.py
+++ b/server/text_generation_server/utils/awq/quantize/qmodule.py
@@ -35,10 +35,7 @@ class WQLinear(nn.Module):
         self.qweight = qweight
         self.qzeros = qzeros
         self.scales = scales
-        if bias:
-            self.bias = bias
-        else:
-            self.bias = None
+        self.bias = bias
 
     @torch.no_grad()
     def forward(self, x):

--- a/server/text_generation_server/utils/layers.py
+++ b/server/text_generation_server/utils/layers.py
@@ -335,7 +335,7 @@ def get_linear(weight, bias, quantize):
             qweight=qweight,
             qzeros=qzeros,
             scales=scales,
-            bias=bias is not None,
+            bias=bias,
         )
     else:
         raise NotImplementedError(f"Quantization `{quantize}` is not implemented yet.")


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

When the linear layer use bias in awq, previous code will convert bias from torch float16 tensor to bool. It causes WQLinear forward calculation errors.

An example is as follows:
~~~bash
>> bias
tensor([-9.4141e-01,  1.8750e+00, -7.4219e-01,  ...,  7.7188e-05,
        -6.5193e-03, -2.4242e-03], device='cuda:0', dtype=torch.float16)
>> bias = bias is not None # https://github.com/huggingface/text-generation-inference/blob/630800eed37b15c4b0c9eb8e6ab47212026720f7/server/text_generation_server/utils/layers.py#L358
True
>>  out  # https://github.com/huggingface/text-generation-inference/blob/630800eed37b15c4b0c9eb8e6ab47212026720f7/server/text_generation_server/utils/awq/quantize/qmodule.py#L46
tensor([[ 0.8882, -1.0068,  0.6802,  ...,  0.2141,  0.0244, -0.1851],
        [ 0.5547, -0.4036,  0.5908,  ...,  0.1984,  0.3252, -0.0175],
        [ 0.8882, -1.0068,  0.6802,  ...,  0.2141,  0.0244, -0.1851],
        ...,
        [ 0.5547, -0.4036,  0.5908,  ...,  0.1984,  0.3252, -0.0175],
        [ 0.8882, -1.0068,  0.6802,  ...,  0.2141,  0.0244, -0.1851],
        [-0.8950, -0.0801, -0.7061,  ..., -0.0229,  0.0259, -0.0086]],
       device='cuda:0', dtype=torch.float16)
>> out + self.bias if self.bias is not None else out # https://github.com/huggingface/text-generation-inference/blob/630800eed37b15c4b0c9eb8e6ab47212026720f7/server/text_generation_server/utils/awq/quantize/qmodule.py#L49C15-L49C64
tensor([[ 1.8887, -0.0068,  1.6797,  ...,  1.2139,  1.0244,  0.8149],
        [ 1.5547,  0.5967,  1.5908,  ...,  1.1982,  1.3252,  0.9824],
        [ 1.8887, -0.0068,  1.6797,  ...,  1.2139,  1.0244,  0.8149],
        ...,
        [ 1.5547,  0.5967,  1.5908,  ...,  1.1982,  1.3252,  0.9824],
        [ 1.8887, -0.0068,  1.6797,  ...,  1.2139,  1.0244,  0.8149],
        [ 0.1050,  0.9199,  0.2939,  ...,  0.9771,  1.0264,  0.9912]],
       device='cuda:0', dtype=torch.float16)
~~~


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
