### PR TITLE
feat: add mocked http request tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,6 +2820,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-stream",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -43,6 +43,7 @@ utoipa-swagger-ui = { version = "3.1.5", features = ["axum"] }
 ngrok = { version = "0.13.1", features = ["axum"], optional = true }
 hf-hub = "0.3.1"
 init-tracing-opentelemetry = { version = "0.14.1", features = ["opentelemetry-otlp"] }
+tower = "0.4.13"
 
 [build-dependencies]
 vergen = { version = "8.2.5", features = ["build", "git", "gitcl"] }

--- a/router/client/src/sharded_client.rs
+++ b/router/client/src/sharded_client.rs
@@ -17,6 +17,11 @@ impl ShardedClient {
         Self { clients }
     }
 
+    /// Create a new ShardedClient with no shards. Used for testing
+    pub fn empty() -> Self {
+        Self { clients: vec![] }
+    }
+
     /// Create a new ShardedClient from a master client. The master client will communicate with
     /// the other shards and returns all uris/unix sockets with the `service_discovery` gRPC method.
     async fn from_master_client(mut master_client: Client) -> Result<Self> {

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -138,6 +138,9 @@ pub(crate) struct GenerateParameters {
     #[serde(default)]
     #[schema(exclusive_minimum = 0, nullable = true, default = "null", example = 5)]
     pub top_n_tokens: Option<u32>,
+
+    // useful when testing the router in isolation
+    skip_generation: Option<bool>,
 }
 
 fn default_max_new_tokens() -> Option<u32> {
@@ -162,6 +165,7 @@ fn default_parameters() -> GenerateParameters {
         decoder_input_details: false,
         seed: None,
         top_n_tokens: None,
+        skip_generation: None,
     }
 }
 


### PR DESCRIPTION
This PR implements two http request tests, and adds helper functions to test JSON requests and expected outputs.

```
test server::tests::test_echo_inputs_when_skip_generation ... ok
test server::tests::test_return_json_error_on_empty_inputs ... ok
```

Notes: 
- this pr adds `tower = "0.4.13"` so we can use the `tower::util::ServiceExt` trait to allow `oneshot` requests in the tests without starting an HTTP server. 
- `skip_generation` has been added to  `GenerateParameters` as a way to avoid making requests to the router. 

@Narsil and @OlivierDehaene please let me know what you think of this approach and if there is a better way to implement tests (the longer term goal is to improve TGI's API and these tests may be helpful when extending the API)
