### PR TITLE
feat: add tokenizer-config-path to launcher args

### DIFF
--- a/docs/source/basic_tutorials/launcher.md
+++ b/docs/source/basic_tutorials/launcher.md
@@ -355,6 +355,14 @@ Options:
           [env: NGROK_EDGE=]
 
 ```
+### TOKENIZER_CONFIG_PATH
+```shell
+      --tokenizer-config-path <TOKENIZER_CONFIG_PATH>
+          The path to the tokenizer config file. This path is used to load the tokenizer configuration which may include a `chat_template`. If not provided, the default config will be used from the model hub.
+          
+          [env: TOKENIZER_CONFIG_PATH=]
+    
+```
 ## ENV
 ```shell
   -e, --env

--- a/docs/source/basic_tutorials/launcher.md
+++ b/docs/source/basic_tutorials/launcher.md
@@ -355,13 +355,13 @@ Options:
           [env: NGROK_EDGE=]
 
 ```
-### TOKENIZER_CONFIG_PATH
+## TOKENIZER_CONFIG_PATH
 ```shell
       --tokenizer-config-path <TOKENIZER_CONFIG_PATH>
-          The path to the tokenizer config file. This path is used to load the tokenizer configuration which may include a `chat_template`. If not provided, the default config will be used from the model hub.
+          The path to the tokenizer config file. This path is used to load the tokenizer configuration which may include a `chat_template`. If not provided, the default config will be used from the model hub
           
           [env: TOKENIZER_CONFIG_PATH=]
-    
+
 ```
 ## ENV
 ```shell

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -372,7 +372,7 @@ struct Args {
     /// include a `chat_template`. If not provided, the default config will be used from the model hub.
     #[clap(long, env)]
     tokenizer_config_path: Option<String>,
-    
+
     /// Display a lot of information about your runtime environment
     #[clap(long, short, action)]
     env: bool,

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -372,7 +372,7 @@ struct Args {
     #[clap(long, env)]
     tokenizer_config_path: Option<String>,
 
-    /// The path to the tokenizer config file. This path is used to load the tokenizer configuration which may 
+    /// The path to the tokenizer config file. This path is used to load the tokenizer configuration which may
     /// include a `chat_template`. If not provided, the default config will be used from the model hub.
     #[clap(long, short, action)]
     env: bool,

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -371,6 +371,10 @@ struct Args {
     /// Display a lot of information about your runtime environment
     #[clap(long, short, action)]
     env: bool,
+
+    /// path to the tokenizer config file
+    #[clap(long, env)]
+    tokenizer_config_path: Option<String>,
 }
 
 #[derive(Debug)]
@@ -1015,6 +1019,12 @@ fn spawn_webserver(
         "--tokenizer-name".to_string(),
         args.model_id,
     ];
+
+    // Tokenizer config path
+    if let Some(ref tokenizer_config_path) = args.tokenizer_config_path {
+        router_args.push("--tokenizer-config-path".to_string());
+        router_args.push(tokenizer_config_path.to_string());
+    }
 
     // Model optional max batch total tokens
     if let Some(max_batch_total_tokens) = args.max_batch_total_tokens {

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -368,12 +368,12 @@ struct Args {
     #[clap(long, env)]
     ngrok_edge: Option<String>,
 
-    /// path to the tokenizer config file
-    #[clap(long, env)]
-    tokenizer_config_path: Option<String>,
-
     /// The path to the tokenizer config file. This path is used to load the tokenizer configuration which may
     /// include a `chat_template`. If not provided, the default config will be used from the model hub.
+    #[clap(long, env)]
+    tokenizer_config_path: Option<String>,
+    
+    /// Display a lot of information about your runtime environment
     #[clap(long, short, action)]
     env: bool,
 }

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -368,13 +368,13 @@ struct Args {
     #[clap(long, env)]
     ngrok_edge: Option<String>,
 
-    /// Display a lot of information about your runtime environment
-    #[clap(long, short, action)]
-    env: bool,
-
     /// path to the tokenizer config file
     #[clap(long, env)]
     tokenizer_config_path: Option<String>,
+
+    /// Display a lot of information about your runtime environment
+    #[clap(long, short, action)]
+    env: bool,
 }
 
 #[derive(Debug)]

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -372,7 +372,8 @@ struct Args {
     #[clap(long, env)]
     tokenizer_config_path: Option<String>,
 
-    /// Display a lot of information about your runtime environment
+    /// The path to the tokenizer config file. This path is used to load the tokenizer configuration which may 
+    /// include a `chat_template`. If not provided, the default config will be used from the model hub.
     #[clap(long, short, action)]
     env: bool,
 }


### PR DESCRIPTION
This PR adds the `tokenizer-config-path` to the launcher and passes it to the router

Fixes: https://github.com/huggingface/text-generation-inference/pull/1427