### PR TITLE
fix: tokenizer config should use local model path when possible

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -37,7 +37,7 @@ pub struct HubTokenizerConfig {
 }
 
 impl HubTokenizerConfig {
-    pub fn from_file(filename: &str) -> Self {
+    pub fn from_file(filename: &std::path::Path) -> Self {
         let content = std::fs::read_to_string(filename).unwrap();
         serde_json::from_str(&content).unwrap_or_default()
     }

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -156,9 +156,6 @@ async fn main() -> Result<(), RouterError> {
 
     // Load tokenizer config
     // This will be used to format the chat template
-    let tokenizer_config_full_path = if tokenizer_config_path.is_none() && local_model {
-        // if no tokenizer config path is provided, we default to the local tokenizer config
-        Some(local_path.join("tokenizer_config.json"))
     if let Some(tokenizer_config_path) = tokenizer_config_path {
         Some(std::path::PathBuf::from(tokenizer_config_path))
     } else if local_model  {

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -159,8 +159,10 @@ async fn main() -> Result<(), RouterError> {
     let tokenizer_config_full_path = if tokenizer_config_path.is_none() && local_model {
         // if no tokenizer config path is provided, we default to the local tokenizer config
         Some(local_path.join("tokenizer_config.json"))
-    } else if let Some(tokenizer_config_path) = tokenizer_config_path {
+    if let Some(tokenizer_config_path) = tokenizer_config_path {
         Some(std::path::PathBuf::from(tokenizer_config_path))
+    } else if local_model  {
+        Some(local_path.join("tokenizer_config.json"))
     } else {
         None
     };


### PR DESCRIPTION
This PR fixes the issue with loading a local tokenizer config. Previously the default functionality would look in the current working directory. Now if a local model path is specified we will check that directory for the tokenizer_config.

## Examples of valid commands

uses tokenizer_config from hub
```
text-generation-launcher --model-id HuggingFaceH4/zephyr-7b-beta
```

use tokenizer_config from local model path
```
text-generation-launcher \
  --model-id ~/.cache/huggingface/hub/models--HuggingFaceH4--zephyr-7b-beta/snapshots/dc24cabd13eacd3ae3a5fe574bd645483a335a4a/
```

use specific tokenizer_config file
```
 text-generation-launcher \
  --model-id ~/.cache/huggingface/hub/models--HuggingFaceH4--zephyr-7b-beta/snapshots/dc24cabd13eacd3ae3a5fe574bd645483a335a4a/ \
  --tokenizer-config-path ~/.cache/huggingface/hub/models--HuggingFaceH4--zephyr-7b-beta/snapshots/dc24cabd13eacd3ae3a5fe574bd645483a335a4a/tokenizer_config.json


```