### PR TITLE
chore: bump ci rust version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,10 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71.0
+          # Released on: 28 December, 2023
+          # Branched from master on: 10 November, 2023
+          # https://releases.rs/docs/1.75.0/
+          toolchain: 1.75.0
           override: true
           components: rustfmt, clippy
       - name: Install Protoc


### PR DESCRIPTION
This PR bumps the rust toolchain in CI to resolve the CI build issue

```bash
  Downloaded crossbeam-utils v0.8.19
  Downloaded crc32fast v1.3.2
error: failed to compile `text-generation-router v1.4.0 (/home/runner/work/text-generation-inference/text-generation-inference/router)`, intermediate artifacts can be found at `/home/runner/work/text-generation-inference/text-generation-inference/target`

Caused by:
  package `clap_lex v0.7.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.71.0
  Either upgrade to rustc 1.74 or newer, or use
  cargo update -p clap_lex@0.7.0 --precise ver
  where `ver` is the latest version of `clap_lex` supporting rustc 1.71.0
make: *** [Makefile:12: install-router] Error 101
```