### PR TITLE
Bugfix: eos and bos tokens positions are inconsistent

### DIFF
--- a/router/src/infer.rs
+++ b/router/src/infer.rs
@@ -113,7 +113,7 @@ impl Infer {
             queue,
             shared,
             limit_concurrent_requests: semaphore,
-            template: (template, eos_token, bos_token),
+            template: (template, bos_token, eos_token),
         }
     }
 


### PR DESCRIPTION
# What does this PR do?

Fixes an inconsistency how the template object is created (line 116) and read (line 195).  I fixed it to be consistent with the code comments (line 36).  This bug causes the bos/eos tokens to be swapped when the chat_template is applied.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@drbh 
