### PR TITLE
fix: prefer seed 1 in all tests

### DIFF
--- a/integration-tests/models/__snapshots__/test_bloom_560m/test_bloom_560m.json
+++ b/integration-tests/models/__snapshots__/test_bloom_560m/test_bloom_560m.json
@@ -60,69 +60,70 @@
         "text": " d'abord"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
-        "id": 578,
-        "logprob": -1.6591797,
+        "id": 2997,
+        "logprob": -4.4101562,
         "special": false,
-        "text": " le"
+        "text": " vous"
       },
       {
-        "id": 5608,
-        "logprob": -2.4492188,
+        "id": 71256,
+        "logprob": -5.3828125,
         "special": false,
-        "text": " faire"
+        "text": " retrouver"
       },
       {
-        "id": 159570,
-        "logprob": -6.6835938,
+        "id": 693,
+        "logprob": -2.1308594,
         "special": false,
-        "text": " réch"
+        "text": " à"
       },
       {
-        "id": 810,
-        "logprob": 0.0,
+        "id": 366,
+        "logprob": -1.5234375,
         "special": false,
-        "text": "au"
+        "text": " la"
       },
       {
-        "id": 12736,
-        "logprob": 0.0,
+        "id": 221398,
+        "logprob": -2.671875,
         "special": false,
-        "text": "ffer"
+        "text": " terrasse"
       },
       {
-        "id": 1742,
-        "logprob": -2.5175781,
+        "id": 1375,
+        "logprob": -4.375,
         "special": false,
-        "text": " au"
+        "text": " pour"
       },
       {
-        "id": 6105,
-        "logprob": -2.0078125,
+        "id": 86887,
+        "logprob": -4.859375,
         "special": false,
-        "text": " bain"
+        "text": " essayer"
       },
       {
-        "id": 88254,
-        "logprob": -0.12695312,
+        "id": 2155,
+        "logprob": -2.7519531,
         "special": false,
-        "text": "-mar"
+        "text": " ce"
       },
       {
-        "id": 641,
-        "logprob": 0.0,
+        "id": 5743,
+        "logprob": -3.1992188,
         "special": false,
-        "text": "ie"
+        "text": " jus"
       },
       {
-        "id": 2940,
-        "logprob": -3.5175781,
+        "id": 1479,
+        "logprob": -3.3203125,
         "special": false,
-        "text": " avec"
+        "text": " qui"
       }
-    ]
+    ],
+    "top_tokens": null
   },
-  "generated_text": " le faire réchauffer au bain-marie avec"
+  "generated_text": " vous retrouver à la terrasse pour essayer ce jus qui"
 }

--- a/integration-tests/models/__snapshots__/test_bloom_560m/test_bloom_560m_all_params.json
+++ b/integration-tests/models/__snapshots__/test_bloom_560m/test_bloom_560m_all_params.json
@@ -30,7 +30,7 @@
         "text": " d'abord"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 408,
@@ -39,60 +39,61 @@
         "text": " que"
       },
       {
-        "id": 366,
-        "logprob": -1.2939453,
-        "special": false,
-        "text": " la"
-      },
-      {
-        "id": 8769,
-        "logprob": -0.3708496,
-        "special": false,
-        "text": " personne"
-      },
-      {
-        "id": 1479,
-        "logprob": -2.2871094,
-        "special": false,
-        "text": " qui"
-      },
-      {
         "id": 2997,
-        "logprob": -0.8671875,
+        "logprob": -1.2939453,
         "special": false,
         "text": " vous"
       },
       {
-        "id": 35977,
-        "logprob": -1.5097656,
+        "id": 116938,
+        "logprob": -0.8618164,
         "special": false,
-        "text": " suit"
-      },
-      {
-        "id": 21558,
-        "logprob": -0.07891846,
-        "special": false,
-        "text": " ait"
+        "text": " ayez"
       },
       {
         "id": 447,
-        "logprob": -0.12695312,
+        "logprob": 0.0,
         "special": false,
         "text": " un"
       },
       {
-        "id": 78606,
-        "logprob": -2.21875,
+        "id": 11299,
+        "logprob": -0.20141602,
         "special": false,
-        "text": " profil"
+        "text": " compte"
       },
       {
-        "id": 3899,
-        "logprob": -1.3535156,
+        "id": 198236,
+        "logprob": -0.4741211,
         "special": false,
-        "text": " bien"
+        "text": " PayPal"
+      },
+      {
+        "id": 17,
+        "logprob": 0.0,
+        "special": false,
+        "text": "."
+      },
+      {
+        "id": 12424,
+        "logprob": -0.6040039,
+        "special": false,
+        "text": " Pour"
+      },
+      {
+        "id": 11676,
+        "logprob": -0.9741211,
+        "special": false,
+        "text": " cela"
+      },
+      {
+        "id": 915,
+        "logprob": -0.31323242,
+        "special": false,
+        "text": " :"
       }
-    ]
+    ],
+    "top_tokens": null
   },
-  "generated_text": "Pour déguster un ortolan, il faut tout d'abord que la personne qui vous suit ait un profil bien"
+  "generated_text": "Pour déguster un ortolan, il faut tout d'abord que vous ayez un compte PayPal. Pour cela :"
 }

--- a/integration-tests/models/__snapshots__/test_bloom_560m_sharded/test_bloom_560m_sharded.json
+++ b/integration-tests/models/__snapshots__/test_bloom_560m_sharded/test_bloom_560m_sharded.json
@@ -11,47 +11,47 @@
       },
       {
         "id": 49833,
-        "logprob": -10.5390625,
+        "logprob": -10.5859375,
         "text": " dég"
       },
       {
         "id": 21543,
-        "logprob": -0.14758301,
+        "logprob": -0.14794922,
         "text": "uster"
       },
       {
         "id": 447,
-        "logprob": -1.9296875,
+        "logprob": -1.9277344,
         "text": " un"
       },
       {
         "id": 46341,
-        "logprob": -15.4453125,
+        "logprob": -15.3203125,
         "text": " ort"
       },
       {
         "id": 35567,
-        "logprob": -7.59375,
+        "logprob": -7.5664062,
         "text": "olan"
       },
       {
         "id": 15,
-        "logprob": -1.3994141,
+        "logprob": -1.3974609,
         "text": ","
       },
       {
         "id": 1669,
-        "logprob": -1.578125,
+        "logprob": -1.5351562,
         "text": " il"
       },
       {
         "id": 11580,
-        "logprob": -0.9453125,
+        "logprob": -0.9423828,
         "text": " faut"
       },
       {
         "id": 3913,
-        "logprob": -3.7011719,
+        "logprob": -3.671875,
         "text": " tout"
       },
       {
@@ -60,69 +60,70 @@
         "text": " d'abord"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
-        "id": 578,
-        "logprob": -1.6474609,
+        "id": 2997,
+        "logprob": -4.4101562,
         "special": false,
-        "text": " le"
+        "text": " vous"
       },
       {
-        "id": 5608,
-        "logprob": -2.5097656,
+        "id": 71256,
+        "logprob": -5.421875,
         "special": false,
-        "text": " faire"
+        "text": " retrouver"
       },
       {
-        "id": 159570,
-        "logprob": -6.65625,
+        "id": 693,
+        "logprob": -2.1738281,
         "special": false,
-        "text": " réch"
+        "text": " à"
       },
       {
-        "id": 810,
-        "logprob": 0.0,
+        "id": 366,
+        "logprob": -1.5322266,
         "special": false,
-        "text": "au"
+        "text": " la"
       },
       {
-        "id": 12736,
-        "logprob": 0.0,
+        "id": 221398,
+        "logprob": -2.6640625,
         "special": false,
-        "text": "ffer"
+        "text": " terrasse"
       },
       {
-        "id": 1742,
-        "logprob": -2.5859375,
+        "id": 1375,
+        "logprob": -4.375,
         "special": false,
-        "text": " au"
+        "text": " pour"
       },
       {
-        "id": 6105,
-        "logprob": -2.03125,
+        "id": 86887,
+        "logprob": -4.8203125,
         "special": false,
-        "text": " bain"
+        "text": " essayer"
       },
       {
-        "id": 88254,
-        "logprob": -0.12695312,
+        "id": 2155,
+        "logprob": -2.7421875,
         "special": false,
-        "text": "-mar"
+        "text": " ce"
       },
       {
-        "id": 641,
-        "logprob": 0.0,
+        "id": 5743,
+        "logprob": -3.1757812,
         "special": false,
-        "text": "ie"
+        "text": " jus"
       },
       {
-        "id": 2940,
-        "logprob": -3.5175781,
+        "id": 1479,
+        "logprob": -3.3554688,
         "special": false,
-        "text": " avec"
+        "text": " qui"
       }
-    ]
+    ],
+    "top_tokens": null
   },
-  "generated_text": " le faire réchauffer au bain-marie avec"
+  "generated_text": " vous retrouver à la terrasse pour essayer ce jus qui"
 }

--- a/integration-tests/models/__snapshots__/test_flash_awq/test_flash_llama_awq_all_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_awq/test_flash_llama_awq_all_params.json
@@ -30,7 +30,7 @@
         "text": "?"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 13,
@@ -39,61 +39,61 @@
         "text": "\n"
       },
       {
-        "id": 4013,
-        "logprob": -2.203125,
+        "id": 13,
+        "logprob": -1.078125,
         "special": false,
-        "text": "This"
+        "text": "\n"
       },
       {
-        "id": 1139,
-        "logprob": -0.23693848,
+        "id": 20001,
+        "logprob": -1.8847656,
         "special": false,
-        "text": " question"
+        "text": "Comment"
       },
       {
-        "id": 756,
+        "id": 29901,
         "logprob": 0.0,
         "special": false,
-        "text": " has"
-      },
-      {
-        "id": 1063,
-        "logprob": -0.076538086,
-        "special": false,
-        "text": " been"
-      },
-      {
-        "id": 4433,
-        "logprob": 0.0,
-        "special": false,
-        "text": " asked"
-      },
-      {
-        "id": 1784,
-        "logprob": -1.1367188,
-        "special": false,
-        "text": " many"
-      },
-      {
-        "id": 3064,
-        "logprob": 0.0,
-        "special": false,
-        "text": " times"
-      },
-      {
-        "id": 322,
-        "logprob": -1.7460938,
-        "special": false,
-        "text": " and"
+        "text": ":"
       },
       {
         "id": 306,
-        "logprob": 0.0,
+        "logprob": -0.31201172,
         "special": false,
         "text": " I"
+      },
+      {
+        "id": 30010,
+        "logprob": -0.077697754,
+        "special": false,
+        "text": "’"
+      },
+      {
+        "id": 29885,
+        "logprob": 0.0,
+        "special": false,
+        "text": "m"
+      },
+      {
+        "id": 28931,
+        "logprob": -0.14685059,
+        "special": false,
+        "text": " voting"
+      },
+      {
+        "id": 304,
+        "logprob": 0.0,
+        "special": false,
+        "text": " to"
+      },
+      {
+        "id": 3802,
+        "logprob": 0.0,
+        "special": false,
+        "text": " close"
       }
     ],
     "top_tokens": null
   },
-  "generated_text": "What is Deep Learning?\nThis question has been asked many times and I"
+  "generated_text": "What is Deep Learning?\n\nComment: I’m voting to close"
 }

--- a/integration-tests/models/__snapshots__/test_flash_falcon/test_flash_falcon_all_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_falcon/test_flash_falcon_all_params.json
@@ -11,88 +11,89 @@
       },
       {
         "id": 1622,
-        "logprob": -7.8125,
+        "logprob": -7.7421875,
         "text": "af"
       },
       {
         "id": 249,
-        "logprob": -4.5,
+        "logprob": -4.484375,
         "text": "at"
       },
       {
         "id": 1480,
-        "logprob": -10.875,
+        "logprob": -10.890625,
         "text": "ron"
       },
       {
         "id": 37,
-        "logprob": -3.6875,
+        "logprob": -3.6757812,
         "text": ":"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 836,
-        "logprob": -1.265625,
+        "logprob": -1.2822266,
         "special": false,
         "text": " i"
       },
       {
         "id": 18,
-        "logprob": -0.119628906,
+        "logprob": -0.11621094,
         "special": false,
         "text": "'"
       },
       {
-        "id": 298,
-        "logprob": -2.265625,
+        "id": 88,
+        "logprob": -0.11016846,
         "special": false,
-        "text": "ve"
-      },
-      {
-        "id": 650,
-        "logprob": -0.49804688,
-        "special": false,
-        "text": " been"
+        "text": "m"
       },
       {
         "id": 1241,
-        "logprob": 0.0,
+        "logprob": -0.9682617,
         "special": false,
         "text": " using"
       },
       {
-        "id": 334,
-        "logprob": 0.0,
+        "id": 61734,
+        "logprob": -1.8984375,
         "special": false,
-        "text": " it"
-      },
-      {
-        "id": 312,
-        "logprob": -1.2421875,
-        "special": false,
-        "text": " for"
-      },
-      {
-        "id": 909,
-        "logprob": -0.99609375,
-        "special": false,
-        "text": " years"
+        "text": " gnome"
       },
       {
         "id": 193,
-        "logprob": -0.30273438,
+        "logprob": -0.21923828,
         "special": false,
         "text": "\n"
       },
       {
-        "id": 807,
-        "logprob": -1.078125,
+        "id": 89,
+        "logprob": -1.1513672,
         "special": false,
-        "text": "ik"
+        "text": "n"
+      },
+      {
+        "id": 35,
+        "logprob": -0.93115234,
+        "special": false,
+        "text": "8"
+      },
+      {
+        "id": 86,
+        "logprob": -0.9790039,
+        "special": false,
+        "text": "k"
+      },
+      {
+        "id": 2512,
+        "logprob": 0.0,
+        "special": false,
+        "text": "99"
       }
-    ]
+    ],
+    "top_tokens": null
   },
-  "generated_text": "Girafatron is obsessed with giraffes, the most glorious animal on the face of this Earth. Giraftron believes all other animals are irrelevant when compared to the glorious majesty of the giraffe.\nDaniel: Hello, Girafatron!\nGirafatron: i've been using it for years\nik"
+  "generated_text": "Girafatron is obsessed with giraffes, the most glorious animal on the face of this Earth. Giraftron believes all other animals are irrelevant when compared to the glorious majesty of the giraffe.\nDaniel: Hello, Girafatron!\nGirafatron: i'm using gnome\nn8k99"
 }

--- a/integration-tests/models/__snapshots__/test_flash_gemma/test_flash_gemma_all_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_gemma/test_flash_gemma_all_params.json
@@ -20,7 +20,7 @@
         "text": " request"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 7539,
@@ -35,20 +35,20 @@
         "text": " are"
       },
       {
-        "id": 671,
-        "logprob": -1.703125,
+        "id": 476,
+        "logprob": -0.453125,
         "special": false,
-        "text": " an"
+        "text": " a"
       },
       {
-        "id": 8727,
-        "logprob": 0.0,
+        "id": 2621,
+        "logprob": -2.078125,
         "special": false,
-        "text": " essential"
+        "text": " key"
       },
       {
         "id": 1702,
-        "logprob": 0.0,
+        "logprob": -0.20117188,
         "special": false,
         "text": " part"
       },
@@ -65,25 +65,25 @@
         "text": " the"
       },
       {
-        "id": 11859,
-        "logprob": -1.6953125,
-        "special": false,
-        "text": " lab"
-      },
-      {
         "id": 2185,
-        "logprob": -1.3125,
+        "logprob": -0.765625,
         "special": false,
         "text": " process"
       },
       {
-        "id": 578,
-        "logprob": -1.5,
+        "id": 604,
+        "logprob": 0.0,
         "special": false,
-        "text": " and"
+        "text": " for"
+      },
+      {
+        "id": 17583,
+        "logprob": -2.609375,
+        "special": false,
+        "text": " sending"
       }
     ],
     "top_tokens": null
   },
-  "generated_text": "Test request forms are an essential part of the lab process and"
+  "generated_text": "Test request forms are a key part of the process for sending"
 }

--- a/integration-tests/models/__snapshots__/test_flash_llama/test_flash_llama_all_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_llama/test_flash_llama_all_params.json
@@ -2,7 +2,7 @@
   "details": {
     "best_of_sequences": null,
     "finish_reason": "stop_sequence",
-    "generated_tokens": 5,
+    "generated_tokens": 4,
     "prefill": [
       {
         "id": 1,
@@ -20,7 +20,7 @@
         "text": "request"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 5229,
@@ -29,31 +29,25 @@
         "text": " failed"
       },
       {
-        "id": 29901,
-        "logprob": -0.44970703,
+        "id": 13,
+        "logprob": -1.4501953,
         "special": false,
-        "text": ":"
+        "text": "\n"
       },
       {
-        "id": 4829,
-        "logprob": -1.8339844,
+        "id": 1576,
+        "logprob": -0.359375,
         "special": false,
-        "text": " Error"
-      },
-      {
-        "id": 297,
-        "logprob": -1.0556641,
-        "special": false,
-        "text": " in"
+        "text": "The"
       },
       {
         "id": 1243,
-        "logprob": 0.0,
+        "logprob": -0.7578125,
         "special": false,
         "text": " test"
       }
     ],
     "top_tokens": null
   },
-  "generated_text": "Test request failed: Error in test"
+  "generated_text": "Test request failed\nThe test"
 }

--- a/integration-tests/models/__snapshots__/test_flash_llama_gptq/test_flash_llama_gptq_all_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_llama_gptq/test_flash_llama_gptq_all_params.json
@@ -11,26 +11,26 @@
       },
       {
         "id": 4321,
-        "logprob": -9.84375,
+        "logprob": -9.7890625,
         "text": "Test"
       },
       {
         "id": 2009,
-        "logprob": -9.6015625,
+        "logprob": -9.625,
         "text": "request"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 29899,
-        "logprob": -1.5625,
+        "logprob": -1.5234375,
         "special": false,
         "text": "-"
       },
       {
         "id": 1454,
-        "logprob": -0.20410156,
+        "logprob": -0.20019531,
         "special": false,
         "text": "for"
       },
@@ -54,36 +54,36 @@
       },
       {
         "id": 396,
-        "logprob": -0.27685547,
+        "logprob": -0.27392578,
         "special": false,
         "text": " #"
       },
       {
-        "id": 29906,
-        "logprob": -0.4970703,
+        "id": 29946,
+        "logprob": -2.0761719,
         "special": false,
-        "text": "2"
+        "text": "4"
       },
       {
-        "id": 29900,
-        "logprob": -0.80615234,
+        "id": 29945,
+        "logprob": -0.8120117,
         "special": false,
-        "text": "0"
+        "text": "5"
       },
       {
-        "id": 29896,
-        "logprob": 0.0,
+        "id": 29953,
+        "logprob": -0.78271484,
         "special": false,
-        "text": "1"
+        "text": "6"
       },
       {
-        "id": 29955,
-        "logprob": -1.0751953,
+        "id": 29929,
+        "logprob": -0.5830078,
         "special": false,
-        "text": "7"
+        "text": "9"
       }
     ],
     "top_tokens": null
   },
-  "generated_text": "Test request-for-comment: #2017"
+  "generated_text": "Test request-for-comment: #4569"
 }

--- a/integration-tests/models/__snapshots__/test_flash_medusa/test_flash_medusa_all_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_medusa/test_flash_medusa_all_params.json
@@ -10,89 +10,90 @@
         "text": "<s>"
       },
       {
-        "id": 338,
-        "logprob": -10.0078125,
-        "text": "is"
-      },
-      {
         "id": 21784,
-        "logprob": -15.515625,
+        "logprob": -10.1875,
         "text": "Deep"
       },
       {
         "id": 29257,
-        "logprob": -2.8847656,
+        "logprob": -3.125,
         "text": "Learning"
       },
       {
         "id": 29973,
-        "logprob": -4.140625,
+        "logprob": -7.5664062,
         "text": "?"
+      },
+      {
+        "id": 29871,
+        "logprob": -4.3984375,
+        "text": ""
       }
     ],
-    "seed": 0,
+    "seed": 1337,
     "tokens": [
       {
+        "id": 243,
+        "logprob": 0.0,
+        "special": false,
+        "text": ""
+      },
+      {
+        "id": 162,
+        "logprob": 0.0,
+        "special": false,
+        "text": ""
+      },
+      {
+        "id": 170,
+        "logprob": -1.0087891,
+        "special": false,
+        "text": ""
+      },
+      {
+        "id": 163,
+        "logprob": 0.0,
+        "special": false,
+        "text": "🧠"
+      },
+      {
         "id": 13,
-        "logprob": -1.1582031,
+        "logprob": 0.0,
         "special": false,
         "text": "\n"
       },
       {
-        "id": 2772,
-        "logprob": -0.23083496,
+        "id": 797,
+        "logprob": -0.8491211,
         "special": false,
-        "text": "De"
+        "text": "In"
       },
       {
-        "id": 1022,
+        "id": 278,
+        "logprob": -0.4987793,
+        "special": false,
+        "text": " the"
+      },
+      {
+        "id": 3030,
+        "logprob": -2.4023438,
+        "special": false,
+        "text": " context"
+      },
+      {
+        "id": 310,
         "logprob": 0.0,
         "special": false,
-        "text": "ep"
+        "text": " of"
       },
       {
-        "id": 6509,
-        "logprob": 0.0,
+        "id": 319,
+        "logprob": -0.45654297,
         "special": false,
-        "text": " learning"
-      },
-      {
-        "id": 29892,
-        "logprob": -0.61816406,
-        "special": false,
-        "text": ","
-      },
-      {
-        "id": 607,
-        "logprob": -0.7089844,
-        "special": false,
-        "text": " which"
-      },
-      {
-        "id": 508,
-        "logprob": -1.7724609,
-        "special": false,
-        "text": " can"
-      },
-      {
-        "id": 367,
-        "logprob": 0.0,
-        "special": false,
-        "text": " be"
-      },
-      {
-        "id": 5545,
-        "logprob": 0.0,
-        "special": false,
-        "text": " considered"
-      },
-      {
-        "id": 408,
-        "logprob": -0.3869629,
-        "special": false,
-        "text": " as"
+        "text": " A"
       }
-    ]
+    ],
+    "top_tokens": null
   },
-  "generated_text": "What is Deep Learning?\nDeep learning, which can be considered as"
+  "generated_text": "What is Deep Learning? 🧠\nIn the context of A"
 }

--- a/integration-tests/models/__snapshots__/test_flash_mistral/test_flash_mistral_all_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_mistral/test_flash_mistral_all_params.json
@@ -20,7 +20,7 @@
         "text": "request"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 28747,
@@ -35,55 +35,55 @@
         "text": " Let"
       },
       {
-        "id": 332,
-        "logprob": -2.3359375,
+        "id": 261,
+        "logprob": -2.0078125,
         "special": false,
-        "text": " u"
+        "text": " t"
       },
       {
-        "id": 347,
+        "id": 28732,
+        "logprob": -0.703125,
+        "special": false,
+        "text": "("
+      },
+      {
+        "id": 28715,
+        "logprob": -2.0019531,
+        "special": false,
+        "text": "d"
+      },
+      {
+        "id": 28731,
         "logprob": 0.0,
         "special": false,
-        "text": " be"
+        "text": ")"
       },
       {
-        "id": 325,
-        "logprob": -1.0234375,
+        "id": 327,
+        "logprob": 0.0,
         "special": false,
-        "text": " ("
+        "text": " ="
       },
       {
-        "id": 28734,
-        "logprob": -2.0292969,
+        "id": 281,
+        "logprob": -0.2849121,
         "special": false,
-        "text": "0"
+        "text": " d"
       },
       {
-        "id": 648,
-        "logprob": -1.0439453,
+        "id": 348,
+        "logprob": -0.6401367,
         "special": false,
-        "text": " +"
-      },
-      {
-        "id": 28705,
-        "logprob": -0.24499512,
-        "special": false,
-        "text": " "
+        "text": "**"
       },
       {
         "id": 28770,
-        "logprob": -0.5073242,
+        "logprob": -0.66259766,
         "special": false,
         "text": "3"
-      },
-      {
-        "id": 387,
-        "logprob": -1.5507812,
-        "special": false,
-        "text": " -"
       }
     ],
     "top_tokens": null
   },
-  "generated_text": "Test request: Let u be (0 + 3 -"
+  "generated_text": "Test request: Let t(d) = d**3"
 }

--- a/integration-tests/models/__snapshots__/test_flash_phi/test_flash_phi_all_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_phi/test_flash_phi_all_params.json
@@ -1,8 +1,8 @@
 {
   "details": {
     "best_of_sequences": null,
-    "finish_reason": "stop_sequence",
-    "generated_tokens": 6,
+    "finish_reason": "length",
+    "generated_tokens": 10,
     "prefill": [
       {
         "id": 14402,
@@ -15,7 +15,7 @@
         "text": " request"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 284,
@@ -24,37 +24,61 @@
         "text": " to"
       },
       {
-        "id": 3758,
-        "logprob": -0.62597656,
+        "id": 262,
+        "logprob": -2.0957031,
         "special": false,
-        "text": " send"
+        "text": " the"
       },
       {
-        "id": 1366,
-        "logprob": -0.87060547,
+        "id": 7824,
+        "logprob": 0.0,
         "special": false,
-        "text": " data"
+        "text": " API"
       },
       {
-        "id": 625,
-        "logprob": -0.88427734,
+        "id": 198,
+        "logprob": -1.4794922,
         "special": false,
-        "text": " over"
+        "text": "\n"
       },
       {
-        "id": 257,
-        "logprob": -1.0830078,
+        "id": 50280,
+        "logprob": 0.0,
         "special": false,
-        "text": " a"
+        "text": "        "
       },
       {
-        "id": 3127,
-        "logprob": -1.9462891,
+        "id": 37811,
+        "logprob": 0.0,
         "special": false,
-        "text": " network"
+        "text": "\"\"\""
+      },
+      {
+        "id": 628,
+        "logprob": 0.0,
+        "special": false,
+        "text": "\n\n"
+      },
+      {
+        "id": 50284,
+        "logprob": 0.0,
+        "special": false,
+        "text": "    "
+      },
+      {
+        "id": 4299,
+        "logprob": 0.0,
+        "special": false,
+        "text": "def"
+      },
+      {
+        "id": 1332,
+        "logprob": -1.7158203,
+        "special": false,
+        "text": " test"
       }
     ],
     "top_tokens": null
   },
-  "generated_text": "Test request to send data over a network"
+  "generated_text": "Test request to the API\n        \"\"\"\n\n    def test"
 }

--- a/integration-tests/models/__snapshots__/test_flash_starcoder/test_flash_starcoder_default_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_starcoder/test_flash_starcoder_default_params.json
@@ -11,7 +11,7 @@
       },
       {
         "id": 1459,
-        "logprob": -5.6328125,
+        "logprob": -5.6289062,
         "text": " print"
       },
       {
@@ -21,11 +21,11 @@
       },
       {
         "id": 7656,
-        "logprob": -5.9882812,
+        "logprob": -5.9960938,
         "text": "hello"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 2262,
@@ -59,7 +59,7 @@
       },
       {
         "id": 10896,
-        "logprob": -0.38549805,
+        "logprob": -0.3659668,
         "special": false,
         "text": " World"
       },
@@ -70,10 +70,10 @@
         "text": "\")"
       },
       {
-        "id": 203,
-        "logprob": -0.10632324,
+        "id": 478,
+        "logprob": -2.2929688,
         "special": false,
-        "text": "\n"
+        "text": "\n\n"
       },
       {
         "id": 203,
@@ -83,7 +83,7 @@
       },
       {
         "id": 589,
-        "logprob": -0.20141602,
+        "logprob": 0.0,
         "special": false,
         "text": "def"
       },
@@ -113,7 +113,7 @@
       },
       {
         "id": 426,
-        "logprob": 0.0,
+        "logprob": -0.10021973,
         "special": false,
         "text": "name"
       },
@@ -149,7 +149,7 @@
       },
       {
         "id": 440,
-        "logprob": -0.16027832,
+        "logprob": -0.4741211,
         "special": false,
         "text": "(\""
       },
@@ -184,10 +184,10 @@
         "text": ")"
       },
       {
-        "id": 203,
+        "id": 478,
         "logprob": 0.0,
         "special": false,
-        "text": "\n"
+        "text": "\n\n"
       },
       {
         "id": 203,
@@ -323,13 +323,25 @@
       },
       {
         "id": 313,
-        "logprob": -0.6328125,
+        "logprob": -0.34838867,
         "special": false,
         "text": " \""
       },
       {
+        "id": 844,
+        "logprob": -0.4741211,
+        "special": false,
+        "text": " you"
+      },
+      {
+        "id": 884,
+        "logprob": 0.0,
+        "special": false,
+        "text": " are"
+      },
+      {
         "id": 313,
-        "logprob": -1.7011719,
+        "logprob": 0.0,
         "special": false,
         "text": " \""
       },
@@ -364,30 +376,19 @@
         "text": "))"
       },
       {
-        "id": 203,
+        "id": 478,
         "logprob": 0.0,
         "special": false,
-        "text": "\n"
+        "text": "\n\n"
       },
       {
         "id": 203,
         "logprob": 0.0,
         "special": false,
         "text": "\n"
-      },
-      {
-        "id": 589,
-        "logprob": 0.0,
-        "special": false,
-        "text": "def"
-      },
-      {
-        "id": 1459,
-        "logprob": 0.0,
-        "special": false,
-        "text": " print"
       }
-    ]
+    ],
+    "top_tokens": null
   },
-  "generated_text": "():\n    print(\"Hello World\")\n\ndef print_hello_name(name):\n    print(\"Hello \" + name)\n\ndef print_hello_name_age(name, age):\n    print(\"Hello \" + name + \" \" + str(age))\n\ndef print"
+  "generated_text": "():\n    print(\"Hello World\")\n\n\ndef print_hello_name(name):\n    print(\"Hello \" + name)\n\n\ndef print_hello_name_age(name, age):\n    print(\"Hello \" + name + \" you are \" + str(age))\n\n\n"
 }

--- a/integration-tests/models/__snapshots__/test_flash_starcoder_gptq/test_flash_starcoder_gptq_default_params.json
+++ b/integration-tests/models/__snapshots__/test_flash_starcoder_gptq/test_flash_starcoder_gptq_default_params.json
@@ -16,17 +16,17 @@
       },
       {
         "id": 21017,
-        "logprob": -7.5898438,
+        "logprob": -7.5859375,
         "text": "ometric"
       },
       {
         "id": 81,
-        "logprob": -0.26586914,
+        "logprob": -0.26733398,
         "text": "_"
       },
       {
         "id": 6009,
-        "logprob": -1.6347656,
+        "logprob": -1.640625,
         "text": "mean"
       },
       {
@@ -36,17 +36,17 @@
       },
       {
         "id": 62,
-        "logprob": -5.2382812,
+        "logprob": -5.2304688,
         "text": "L"
       },
       {
         "id": 44,
-        "logprob": -3.0996094,
+        "logprob": -3.1132812,
         "text": ":"
       },
       {
         "id": 1682,
-        "logprob": -1.1025391,
+        "logprob": -1.1083984,
         "text": " List"
       },
       {
@@ -56,16 +56,16 @@
       },
       {
         "id": 1808,
-        "logprob": -0.32226562,
+        "logprob": -0.32177734,
         "text": "float"
       },
       {
         "id": 10794,
-        "logprob": -2.8164062,
+        "logprob": -2.8183594,
         "text": "]):"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 284,
@@ -75,13 +75,13 @@
       },
       {
         "id": 442,
-        "logprob": -1.3134766,
+        "logprob": -1.40625,
         "special": false,
         "text": " return"
       },
       {
         "id": 11665,
-        "logprob": -0.10021973,
+        "logprob": -0.09442139,
         "special": false,
         "text": " reduce"
       },
@@ -129,7 +129,7 @@
       },
       {
         "id": 319,
-        "logprob": -0.42871094,
+        "logprob": -0.3869629,
         "special": false,
         "text": " *"
       },
@@ -176,19 +176,19 @@
         "text": "1"
       },
       {
-        "id": 32,
-        "logprob": -0.31323242,
+        "id": 517,
+        "logprob": -1.3134766,
         "special": false,
-        "text": "."
+        "text": " /"
       },
       {
-        "id": 34,
+        "id": 2069,
         "logprob": 0.0,
         "special": false,
-        "text": "0"
+        "text": " len"
       }
     ],
     "top_tokens": null
   },
-  "generated_text": "\n    return reduce(lambda x, y: x * y, L) ** (1.0"
+  "generated_text": "\n    return reduce(lambda x, y: x * y, L) ** (1 / len"
 }

--- a/integration-tests/models/__snapshots__/test_mamba/test_mamba_all_params.json
+++ b/integration-tests/models/__snapshots__/test_mamba/test_mamba_all_params.json
@@ -30,7 +30,7 @@
         "text": " "
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 187,
@@ -39,22 +39,22 @@
         "text": "\n"
       },
       {
-        "id": 395,
-        "logprob": -0.3125,
+        "id": 11863,
+        "logprob": -1.3125,
         "special": false,
-        "text": "and"
+        "text": "blue"
       },
       {
-        "id": 4797,
+        "id": 285,
+        "logprob": -1.1015625,
+        "special": false,
+        "text": " and"
+      },
+      {
+        "id": 4759,
         "logprob": 0.0,
         "special": false,
-        "text": " blue"
-      },
-      {
-        "id": 9830,
-        "logprob": -1.65625,
-        "special": false,
-        "text": " colors"
+        "text": " green"
       },
       {
         "id": 15,
@@ -63,16 +63,16 @@
         "text": "."
       },
       {
-        "id": 329,
-        "logprob": -2.4375,
+        "id": 380,
+        "logprob": -1.65625,
         "special": false,
-        "text": " A"
+        "text": " The"
       },
       {
-        "id": 1180,
-        "logprob": -1.953125,
+        "id": 3295,
+        "logprob": -0.45117188,
         "special": false,
-        "text": " number"
+        "text": " color"
       },
       {
         "id": 273,
@@ -81,19 +81,19 @@
         "text": " of"
       },
       {
-        "id": 1027,
-        "logprob": -1.5546875,
+        "id": 253,
+        "logprob": 0.0,
         "special": false,
-        "text": " different"
+        "text": " the"
       },
       {
-        "id": 3295,
-        "logprob": -0.97265625,
+        "id": 2329,
+        "logprob": -3.125,
         "special": false,
-        "text": " color"
+        "text": " air"
       }
     ],
     "top_tokens": null
   },
-  "generated_text": "blue, red, yellow, \nand blue colors. A number of different color"
+  "generated_text": "blue, red, yellow, \nblue and green. The color of the air"
 }

--- a/integration-tests/models/__snapshots__/test_mt0_base/test_mt0_base.json
+++ b/integration-tests/models/__snapshots__/test_mt0_base/test_mt0_base.json
@@ -2,7 +2,7 @@
   "details": {
     "best_of_sequences": null,
     "finish_reason": "eos_token",
-    "generated_tokens": 5,
+    "generated_tokens": 7,
     "prefill": [
       {
         "id": 0,
@@ -10,29 +10,41 @@
         "text": "<pad>"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
-        "id": 926,
-        "logprob": -4.3554688,
+        "id": 609,
+        "logprob": -4.1875,
         "special": false,
-        "text": " To"
+        "text": " it"
       },
       {
-        "id": 18295,
-        "logprob": -7.7734375,
+        "id": 259,
+        "logprob": -1.9609375,
         "special": false,
-        "text": " sell"
+        "text": " "
       },
       {
-        "id": 7868,
-        "logprob": -3.9257812,
+        "id": 277,
+        "logprob": -3.15625,
         "special": false,
-        "text": " things"
+        "text": "'"
+      },
+      {
+        "id": 263,
+        "logprob": 0.0,
+        "special": false,
+        "text": "s"
+      },
+      {
+        "id": 16017,
+        "logprob": -2.0,
+        "special": false,
+        "text": " blue"
       },
       {
         "id": 260,
-        "logprob": -2.4179688,
+        "logprob": -1.9638672,
         "special": false,
         "text": "."
       },
@@ -42,7 +54,8 @@
         "special": true,
         "text": "</s>"
       }
-    ]
+    ],
+    "top_tokens": null
   },
-  "generated_text": "To sell things."
+  "generated_text": "it's blue."
 }

--- a/integration-tests/models/__snapshots__/test_mt0_base/test_mt0_base_all_params.json
+++ b/integration-tests/models/__snapshots__/test_mt0_base/test_mt0_base_all_params.json
@@ -10,11 +10,11 @@
         "text": "<pad>"
       }
     ],
-    "seed": 0,
+    "seed": 1,
     "tokens": [
       {
         "id": 16017,
-        "logprob": -0.30908203,
+        "logprob": -0.3112793,
         "special": false,
         "text": " blue"
       },
@@ -25,38 +25,38 @@
         "text": " sky"
       },
       {
+        "id": 305,
+        "logprob": -1.8779297,
+        "special": false,
+        "text": " and"
+      },
+      {
         "id": 259,
-        "logprob": -0.28271484,
+        "logprob": -0.91503906,
         "special": false,
         "text": " "
       },
       {
-        "id": 15484,
-        "logprob": -1.7929688,
+        "id": 262,
+        "logprob": -1.1533203,
         "special": false,
-        "text": "appear"
+        "text": "a"
       },
       {
-        "id": 345,
-        "logprob": -0.8935547,
+        "id": 35622,
+        "logprob": -0.47705078,
         "special": false,
-        "text": "ed"
+        "text": " cloud"
       },
       {
-        "id": 281,
+        "id": 276,
         "logprob": 0.0,
         "special": false,
-        "text": " in"
-      },
-      {
-        "id": 287,
-        "logprob": 0.0,
-        "special": false,
-        "text": " the"
+        "text": "y"
       },
       {
         "id": 20495,
-        "logprob": -0.32299805,
+        "logprob": 0.0,
         "special": false,
         "text": " sky"
       },
@@ -66,7 +66,8 @@
         "special": true,
         "text": "</s>"
       }
-    ]
+    ],
+    "top_tokens": null
   },
-  "generated_text": "Why is the sky blue?blue sky appeared in the sky"
+  "generated_text": "Why is the sky blue?blue sky and a cloudy sky"
 }

--- a/integration-tests/models/__snapshots__/test_mt0_base/test_mt0_base_load.json
+++ b/integration-tests/models/__snapshots__/test_mt0_base/test_mt0_base_load.json
@@ -49,7 +49,8 @@
           "special": true,
           "text": "</s>"
         }
-      ]
+      ],
+      "top_tokens": null
     },
     "generated_text": "Because it is blue"
   },
@@ -103,7 +104,8 @@
           "special": true,
           "text": "</s>"
         }
-      ]
+      ],
+      "top_tokens": null
     },
     "generated_text": "Because it is blue"
   },
@@ -157,7 +159,8 @@
           "special": true,
           "text": "</s>"
         }
-      ]
+      ],
+      "top_tokens": null
     },
     "generated_text": "Because it is blue"
   },
@@ -211,7 +214,8 @@
           "special": true,
           "text": "</s>"
         }
-      ]
+      ],
+      "top_tokens": null
     },
     "generated_text": "Because it is blue"
   }

--- a/integration-tests/models/test_bloom_560m.py
+++ b/integration-tests/models/test_bloom_560m.py
@@ -20,7 +20,7 @@ async def test_bloom_560m(bloom_560, response_snapshot):
         max_new_tokens=10,
         top_p=0.9,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10
@@ -42,7 +42,7 @@ async def test_bloom_560m_all_params(bloom_560, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_bloom_560m_sharded.py
+++ b/integration-tests/models/test_bloom_560m_sharded.py
@@ -20,7 +20,7 @@ async def test_bloom_560m_sharded(bloom_560m_sharded, response_snapshot):
         max_new_tokens=10,
         top_p=0.9,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_flash_awq.py
+++ b/integration-tests/models/test_flash_awq.py
@@ -45,7 +45,7 @@ async def test_flash_llama_awq_all_params(flash_llama_awq, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_flash_falcon.py
+++ b/integration-tests/models/test_flash_falcon.py
@@ -42,7 +42,7 @@ async def test_flash_falcon_all_params(flash_falcon, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_flash_gemma.py
+++ b/integration-tests/models/test_flash_gemma.py
@@ -13,7 +13,6 @@ async def flash_gemma(flash_gemma_handle):
     return flash_gemma_handle.client
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.private
 async def test_flash_gemma(flash_gemma, response_snapshot):
@@ -25,7 +24,6 @@ async def test_flash_gemma(flash_gemma, response_snapshot):
     assert response == response_snapshot
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.private
 async def test_flash_gemma_all_params(flash_gemma, response_snapshot):
@@ -49,7 +47,6 @@ async def test_flash_gemma_all_params(flash_gemma, response_snapshot):
     assert response == response_snapshot
 
 
-# @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.private
 async def test_flash_gemma_load(flash_gemma, generate_load, response_snapshot):

--- a/integration-tests/models/test_flash_gemma.py
+++ b/integration-tests/models/test_flash_gemma.py
@@ -13,7 +13,7 @@ async def flash_gemma(flash_gemma_handle):
     return flash_gemma_handle.client
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.private
 async def test_flash_gemma(flash_gemma, response_snapshot):
@@ -25,7 +25,7 @@ async def test_flash_gemma(flash_gemma, response_snapshot):
     assert response == response_snapshot
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.private
 async def test_flash_gemma_all_params(flash_gemma, response_snapshot):
@@ -42,14 +42,14 @@ async def test_flash_gemma_all_params(flash_gemma, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10
     assert response == response_snapshot
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.private
 async def test_flash_gemma_load(flash_gemma, generate_load, response_snapshot):

--- a/integration-tests/models/test_flash_gemma.py
+++ b/integration-tests/models/test_flash_gemma.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope="module")
 def flash_gemma_handle(launcher):
-    with launcher("gg-hf/gemma-2b", num_shard=1) as handle:
+    with launcher("google/gemma-2b", num_shard=1) as handle:
         yield handle
 
 
@@ -13,7 +13,7 @@ async def flash_gemma(flash_gemma_handle):
     return flash_gemma_handle.client
 
 
-# @pytest.mark.skip
+@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.private
 async def test_flash_gemma(flash_gemma, response_snapshot):
@@ -25,7 +25,7 @@ async def test_flash_gemma(flash_gemma, response_snapshot):
     assert response == response_snapshot
 
 
-# @pytest.mark.skip
+@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.private
 async def test_flash_gemma_all_params(flash_gemma, response_snapshot):

--- a/integration-tests/models/test_flash_llama.py
+++ b/integration-tests/models/test_flash_llama.py
@@ -40,7 +40,7 @@ async def test_flash_llama_all_params(flash_llama, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 5

--- a/integration-tests/models/test_flash_llama.py
+++ b/integration-tests/models/test_flash_llama.py
@@ -43,7 +43,7 @@ async def test_flash_llama_all_params(flash_llama, response_snapshot):
         seed=1,
     )
 
-    assert response.details.generated_tokens == 5
+    assert response.details.generated_tokens == 4
     assert response == response_snapshot
 
 

--- a/integration-tests/models/test_flash_llama_gptq.py
+++ b/integration-tests/models/test_flash_llama_gptq.py
@@ -39,7 +39,7 @@ async def test_flash_llama_gptq_all_params(flash_llama_gptq, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_flash_medusa.py
+++ b/integration-tests/models/test_flash_medusa.py
@@ -26,7 +26,7 @@ async def test_flash_medusa_simple(flash_medusa, response_snapshot):
 @pytest.mark.asyncio
 async def test_flash_medusa_all_params(flash_medusa, response_snapshot):
     response = await flash_medusa.generate(
-        "What is Deep Learning?",
+        "What is Deep Learning? ",
         max_new_tokens=10,
         repetition_penalty=1.2,
         return_full_text=True,
@@ -38,7 +38,7 @@ async def test_flash_medusa_all_params(flash_medusa, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=1,
+        seed=1337,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_flash_medusa.py
+++ b/integration-tests/models/test_flash_medusa.py
@@ -38,7 +38,7 @@ async def test_flash_medusa_all_params(flash_medusa, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_flash_mistral.py
+++ b/integration-tests/models/test_flash_mistral.py
@@ -39,7 +39,7 @@ async def test_flash_mistral_all_params(flash_mistral, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_flash_phi.py
+++ b/integration-tests/models/test_flash_phi.py
@@ -39,7 +39,7 @@ async def test_flash_phi_all_params(flash_phi, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 6

--- a/integration-tests/models/test_flash_phi.py
+++ b/integration-tests/models/test_flash_phi.py
@@ -42,8 +42,11 @@ async def test_flash_phi_all_params(flash_phi, response_snapshot):
         seed=1,
     )
 
-    assert response.details.generated_tokens == 6
-    assert response.generated_text == "Test request to send data over a network"
+    assert response.details.generated_tokens == 10
+    assert (
+        response.generated_text
+        == 'Test request to the API\n        """\n\n    def test'
+    )
     assert response == response_snapshot
 
 

--- a/integration-tests/models/test_flash_starcoder.py
+++ b/integration-tests/models/test_flash_starcoder.py
@@ -33,7 +33,7 @@ async def test_flash_starcoder_default_params(flash_starcoder, response_snapshot
         temperature=0.2,
         top_p=0.95,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 60

--- a/integration-tests/models/test_flash_starcoder_gptq.py
+++ b/integration-tests/models/test_flash_starcoder_gptq.py
@@ -34,7 +34,7 @@ async def test_flash_starcoder_gptq_default_params(
         temperature=0.2,
         top_p=0.95,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
     assert response.details.generated_tokens == 20
     assert response == generous_response_snapshot

--- a/integration-tests/models/test_grammar_llama.py
+++ b/integration-tests/models/test_grammar_llama.py
@@ -34,7 +34,7 @@ async def test_flash_llama_grammar_regex(flash_llama_grammar, response_snapshot)
         "Whats Googles DNS",
         max_new_tokens=10,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
         grammar={
             "type": GrammarType.Regex,  # "regex"
             "value": "((25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(25[0-5]|2[0-4]\\d|[01]?\\d\\d?)",
@@ -52,7 +52,7 @@ async def test_flash_llama_grammar_json(flash_llama_grammar, response_snapshot):
         "info: david holtz like trees and has two cats. ",
         max_new_tokens=100,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
         grammar={
             "type": GrammarType.Json,  # "json"
             "value": json.dumps(
@@ -104,7 +104,7 @@ async def test_flash_llama_grammar_load(
         max_new_tokens=10,
         n=4,
         stop_sequences=[".com"],
-        seed=0,
+        seed=1,
         grammar={
             "type": GrammarType.Regex,  # "regex"
             "value": "[\\w-]+@([\\w-]+\\.)+[\\w-]+",  # email regex
@@ -133,7 +133,7 @@ async def test_flash_llama_grammar_single_load_instance(
         "name: david. email:  ",
         max_new_tokens=10,
         stop_sequences=[".com"],
-        seed=0,
+        seed=1,
         grammar={
             "type": GrammarType.Regex,  # "regex"
             "value": "[\\w-]+@([\\w-]+\\.)+[\\w-]+",  # email regex

--- a/integration-tests/models/test_mamba.py
+++ b/integration-tests/models/test_mamba.py
@@ -39,7 +39,7 @@ async def test_mamba_all_params(fused_kernel_mamba, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 10

--- a/integration-tests/models/test_mamba.py
+++ b/integration-tests/models/test_mamba.py
@@ -45,7 +45,7 @@ async def test_mamba_all_params(fused_kernel_mamba, response_snapshot):
     assert response.details.generated_tokens == 10
     assert (
         response.generated_text
-        == "blue, red, yellow, \nand blue colors. A number of different color"
+        == "blue, red, yellow, \nblue and green. The color of the air"
     )
     assert response == response_snapshot
 

--- a/integration-tests/models/test_mt0_base.py
+++ b/integration-tests/models/test_mt0_base.py
@@ -20,7 +20,7 @@ async def test_mt0_base(mt0_base, response_snapshot):
         max_new_tokens=10,
         top_p=0.9,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 5
@@ -42,7 +42,7 @@ async def test_mt0_base_all_params(mt0_base, response_snapshot):
         typical_p=0.9,
         watermark=True,
         decoder_input_details=True,
-        seed=0,
+        seed=1,
     )
 
     assert response.details.generated_tokens == 9

--- a/integration-tests/models/test_mt0_base.py
+++ b/integration-tests/models/test_mt0_base.py
@@ -23,7 +23,7 @@ async def test_mt0_base(mt0_base, response_snapshot):
         seed=1,
     )
 
-    assert response.details.generated_tokens == 5
+    assert response.details.generated_tokens == 7
     assert response == response_snapshot
 
 

--- a/server/text_generation_server/models/seq2seq_lm.py
+++ b/server/text_generation_server/models/seq2seq_lm.py
@@ -550,7 +550,7 @@ class Seq2SeqLM(Model):
             revision=revision,
             torch_dtype=dtype,
             device_map=(
-                "auto"
+                device
                 if torch.cuda.is_available() and torch.cuda.device_count() > 1
                 else None
             ),


### PR DESCRIPTION
This WIP PR aims to stop tests from being flakey!

Currently `seed=0` in various tests. Since this value is sent via protobuf to the model the `0` seed is ignored and equivalent to `None`. 

This PR starts the work to remove all zero seeds and update all the snapshots to avoid non deterministic output in CI

Ref: https://protobuf.dev/programming-guides/proto3/#default