### PR TITLE
fix: avoid duplicate bos token

### DIFF
--- a/server/text_generation_server/models/custom_modeling/flash_gemma_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_gemma_modeling.py
@@ -87,7 +87,7 @@ class GemmaTokenizerFast(PreTrainedTokenizerFast):
         bos_token="<bos>",
         eos_token="<eos>",
         pad_token="<pad>",
-        add_bos_token=True,
+        add_bos_token=False,
         add_eos_token=False,
         use_default_system_prompt=False,
         **kwargs,


### PR DESCRIPTION
this PR updates the tokenizer to avoid appending the bos token since this is now included in the config and is applied upstream by the chat template

changes to template: https://huggingface.co/google/gemma-7b-it/discussions/42/files