### PR TITLE
Fix async client timeout

### DIFF
--- a/clients/python/text_generation/client.py
+++ b/clients/python/text_generation/client.py
@@ -424,7 +424,7 @@ class AsyncClient:
         self.base_url = base_url
         self.headers = headers
         self.cookies = cookies
-        self.timeout = ClientTimeout(timeout * 60)
+        self.timeout = ClientTimeout(timeout)
 
     async def chat(
         self,


### PR DESCRIPTION
# What does this PR do?

Fixes #1616

According to the [aiohttp.ClientTimeout docs](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout), the arguments should be in seconds. This PR removes the multiplication by 60.

@OlivierDehaene OR @Narsil
