### PR TITLE
Router grammar compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2207,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
 name = "quanta"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,6 +3018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,6 +3108,7 @@ dependencies = [
  "nohash-hasher",
  "opentelemetry",
  "opentelemetry-otlp",
+ "pyo3",
  "rand",
  "reqwest",
  "serde",
@@ -3582,6 +3661,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "untrusted"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ RUN PROTOC_ZIP=protoc-21.12-linux-x86_64.zip && \
     unzip -o $PROTOC_ZIP -d /usr/local 'include/*' && \
     rm -f $PROTOC_ZIP
 
+# pyo3 depends on a shared python library
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+         python3-dev \
+        && rm -rf /var/lib/apt/lists/*
+
 COPY --from=planner /usr/src/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -250,5 +250,7 @@ ENTRYPOINT ["./entrypoint.sh"]
 # Final image
 FROM base
 
+ENV LD_LIBRARY_PATH=/opt/conda/lib/:$LD_LIBRARY_PATH
+
 ENTRYPOINT ["text-generation-launcher"]
 CMD ["--json-output"]

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -8,7 +8,7 @@ use crate::app::App;
 use crate::event::Event;
 use crossterm::ExecutableCommand;
 use std::io;
-use text_generation_client::{GrammarType, NextTokenChooserParameters, ShardedClient};
+use text_generation_client::{NextTokenChooserParameters, ShardedClient};
 use tokenizers::Tokenizer;
 use tokio::sync::{broadcast, mpsc};
 use tui::backend::CrosstermBackend;
@@ -45,8 +45,6 @@ pub async fn run(
         repetition_penalty: repetition_penalty.unwrap_or(1.0),
         frequency_penalty: frequency_penalty.unwrap_or(0.0),
         watermark,
-        grammar: String::new(),
-        grammar_type: GrammarType::None as i32,
         states_to_token_maps: None,
     };
 

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -47,6 +47,7 @@ pub async fn run(
         watermark,
         grammar: String::new(),
         grammar_type: GrammarType::None as i32,
+        states_to_token_maps: None,
     };
 
     // Initialize terminal properties

--- a/proto/generate.proto
+++ b/proto/generate.proto
@@ -80,6 +80,18 @@ message NextTokenChooserParameters {
     string grammar = 10;
     /// grammar type
     GrammarType grammar_type = 11;
+    /// states to token maps
+    StatesToTokenMaps states_to_token_maps = 12;
+}
+
+/// StatesToTokenMaps maps to a BTreeMap<u32, BTreeMap<u32, u32>> in rust (start_state -> (token -> end_state))
+message StatesToTokenMaps {
+    /// Start state
+    repeated uint32 start_states = 1;
+    /// Token
+    repeated uint32 tokens = 2;
+    /// End state
+    repeated uint32 end_states = 3;
 }
 
 message StoppingCriteriaParameters {

--- a/proto/generate.proto
+++ b/proto/generate.proto
@@ -51,12 +51,6 @@ message ClearCacheRequest {
 /// Empty response
 message ClearCacheResponse {}
 
-enum GrammarType {
-    GRAMMAR_TYPE_NONE = 0;
-    GRAMMAR_TYPE_JSON = 1;
-    GRAMMAR_TYPE_REGEX = 2;
-}
-
 message NextTokenChooserParameters {
     /// exponential scaling output probability distribution
     float temperature = 1;
@@ -76,10 +70,6 @@ message NextTokenChooserParameters {
     float frequency_penalty = 9;
     /// token watermarking using "A Watermark for Large Language Models"
     bool watermark = 8;
-    /// grammar (applied if not empty)
-    string grammar = 10;
-    /// grammar type
-    GrammarType grammar_type = 11;
     /// states to token maps
     StatesToTokenMaps states_to_token_maps = 12;
 }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -46,6 +46,7 @@ ngrok = { version = "0.13.1", features = ["axum"], optional = true }
 init-tracing-opentelemetry = { version = "0.14.1", features = ["opentelemetry-otlp"] }
 minijinja = "1.0.10"
 futures-util = "0.3.30"
+pyo3 = "0.20.3"
 
 [build-dependencies]
 vergen = { version = "8.2.5", features = ["build", "git", "gitcl"] }

--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -19,8 +19,11 @@ impl Client {
     pub async fn connect(uri: Uri) -> Result<Self> {
         let channel = Channel::builder(uri).connect().await?;
 
+        let limit = 100 * 1024 * 1024; // 100MB
         Ok(Self {
-            stub: TextGenerationServiceClient::new(channel),
+            stub: TextGenerationServiceClient::new(channel)
+                .max_decoding_message_size(limit)
+                .max_encoding_message_size(limit),
         })
     }
 
@@ -33,8 +36,12 @@ impl Client {
             }))
             .await?;
 
+        let limit = 100 * 1024 * 1024; // 100MB
+        println!("limit: {}", limit);
         Ok(Self {
-            stub: TextGenerationServiceClient::new(channel),
+            stub: TextGenerationServiceClient::new(channel)
+                .max_decoding_message_size(limit)
+                .max_encoding_message_size(limit),
         })
     }
 

--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -130,6 +130,7 @@ impl Client {
                     watermark: true,
                     grammar: String::new(),
                     grammar_type: GrammarType::None as i32,
+                    states_to_token_maps: None,
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {
                     max_new_tokens: max_total_tokens - truncate,

--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -135,8 +135,6 @@ impl Client {
                     repetition_penalty: 1.2,
                     frequency_penalty: 0.1,
                     watermark: true,
-                    grammar: String::new(),
-                    grammar_type: GrammarType::None as i32,
                     states_to_token_maps: None,
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {

--- a/router/client/src/lib.rs
+++ b/router/client/src/lib.rs
@@ -9,8 +9,8 @@ pub use client::Client;
 pub use pb::generate::v2::HealthResponse;
 pub use pb::generate::v2::InfoResponse as ShardInfo;
 pub use pb::generate::v2::{
-    Batch, CachedBatch, FinishReason, GeneratedText, Generation, GrammarType,
-    NextTokenChooserParameters, Request, StatesToTokenMaps, StoppingCriteriaParameters, Tokens,
+    Batch, CachedBatch, FinishReason, GeneratedText, Generation, NextTokenChooserParameters,
+    Request, StatesToTokenMaps, StoppingCriteriaParameters, Tokens,
 };
 pub use sharded_client::ShardedClient;
 use thiserror::Error;

--- a/router/client/src/lib.rs
+++ b/router/client/src/lib.rs
@@ -10,7 +10,7 @@ pub use pb::generate::v2::HealthResponse;
 pub use pb::generate::v2::InfoResponse as ShardInfo;
 pub use pb::generate::v2::{
     Batch, CachedBatch, FinishReason, GeneratedText, Generation, GrammarType,
-    NextTokenChooserParameters, Request, StoppingCriteriaParameters, Tokens,
+    NextTokenChooserParameters, Request, StatesToTokenMaps, StoppingCriteriaParameters, Tokens,
 };
 pub use sharded_client::ShardedClient;
 use thiserror::Error;

--- a/router/src/health.rs
+++ b/router/src/health.rs
@@ -1,6 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use text_generation_client::GrammarType as ProtoGrammarType;
 use text_generation_client::{
     Batch, NextTokenChooserParameters, Request, ShardedClient, StoppingCriteriaParameters,
 };
@@ -46,8 +45,6 @@ impl Health {
                     repetition_penalty: 1.0,
                     frequency_penalty: 0.0,
                     watermark: false,
-                    grammar: String::new(),
-                    grammar_type: ProtoGrammarType::None as i32,
                     states_to_token_maps: None,
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {

--- a/router/src/health.rs
+++ b/router/src/health.rs
@@ -48,6 +48,7 @@ impl Health {
                     watermark: false,
                     grammar: String::new(),
                     grammar_type: ProtoGrammarType::None as i32,
+                    states_to_token_maps: None,
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {
                     max_new_tokens: 1,

--- a/router/src/queue.rs
+++ b/router/src/queue.rs
@@ -343,9 +343,7 @@ enum QueueCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use text_generation_client::{
-        GrammarType as ProtoGrammarType, NextTokenChooserParameters, StoppingCriteriaParameters,
-    };
+    use text_generation_client::{NextTokenChooserParameters, StoppingCriteriaParameters};
     use tracing::info_span;
 
     fn default_entry() -> (
@@ -370,8 +368,6 @@ mod tests {
                     repetition_penalty: 0.0,
                     frequency_penalty: 0.0,
                     watermark: false,
-                    grammar: String::new(),
-                    grammar_type: ProtoGrammarType::None as i32,
                     states_to_token_maps: None,
                 },
                 stopping_parameters: StoppingCriteriaParameters {

--- a/router/src/queue.rs
+++ b/router/src/queue.rs
@@ -372,6 +372,7 @@ mod tests {
                     watermark: false,
                     grammar: String::new(),
                     grammar_type: ProtoGrammarType::None as i32,
+                    states_to_token_maps: None,
                 },
                 stopping_parameters: StoppingCriteriaParameters {
                     ignore_eos_token: false,

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -397,10 +397,23 @@ impl Validation {
                             .await
                             .map_err(|e| ValidationError::InvalidGrammar(e.to_string()))?;
 
+                        // flatten the BTreeMap<u32, BTreeMap<u32, u32>> to 3 Vec<u32> into 4 vectors (start_states, tokens, end_states, offsets)
+                        let mut start_states = vec![];
+                        let mut tokens = vec![];
+                        let mut end_states = vec![];
+
+                        for (start_state, token_map) in _states_to_token_maps.iter() {
+                            for (token, end_state) in token_map.iter() {
+                                start_states.push(*start_state);
+                                tokens.push(*token);
+                                end_states.push(*end_state);
+                            }
+                        }
+
                         let stm = StatesToTokenMaps {
-                            start_states: vec![],
-                            tokens: vec![],
-                            end_states: vec![],
+                            start_states,
+                            tokens,
+                            end_states,
                         };
 
                         (

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -34,7 +34,7 @@ peft = { version = "^0.8.2", optional = true }
 torch = { version = "^2.1.1", optional = true }
 scipy = "^1.11.1"
 pillow = "^10.0.0"
-outlines= { version = "^0.0.27", optional = true }
+outlines= { version = "^0.0.34", optional = true }
 
 [tool.poetry.extras]
 torch = ["torch"]

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -206,11 +206,20 @@ def serve(
             logger.exception("Error when initializing model")
             raise
 
+        max_send_message_size = 100 * 1024 * 1024  # 100 MB
+        max_receive_message_size = 100 * 1024 * 1024  # 100 MB
+
+        server_options = [
+            ("grpc.max_send_message_length", max_send_message_size),
+            ("grpc.max_receive_message_length", max_receive_message_size),
+        ]
+
         server = aio.server(
+            options=server_options,
             interceptors=[
                 ExceptionInterceptor(),
                 UDSOpenTelemetryAioServerInterceptor(),
-            ]
+            ],
         )
         generate_pb2_grpc.add_TextGenerationServiceServicer_to_server(
             TextGenerationService(model, Cache(), quantize, server_urls), server

--- a/server/text_generation_server/utils/logits_process.py
+++ b/server/text_generation_server/utils/logits_process.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 from text_generation_server.pb.generate_pb2 import GrammarType
 
 from outlines.fsm.fsm import RegexFSM
-from outlines.fsm.json_schema import build_regex_from_object
+from outlines.fsm.json_schema import build_regex_from_schema
 from functools import lru_cache
 from typing import List, Optional, DefaultDict
 import time
@@ -512,7 +512,7 @@ class GrammarLogitProcessor(LogitsProcessor):
     def _cached_compile_fsm(grammar_type, schema, tokenizer):
         start_time = time.time()
         if grammar_type == GrammarType.GRAMMAR_TYPE_JSON:
-            schema = build_regex_from_object(schema)
+            schema = build_regex_from_schema(schema)
         elif grammar_type == GrammarType.GRAMMAR_TYPE_REGEX:
             pass  # schema is already a regex just here for clarity
         fsm = RegexFSM(schema, tokenizer)

--- a/server/text_generation_server/utils/logits_process.py
+++ b/server/text_generation_server/utils/logits_process.py
@@ -3,10 +3,8 @@ import torch
 
 from loguru import logger
 from typing import Dict, Union
-from text_generation_server.pb.generate_pb2 import GrammarType
 
 from outlines.fsm.fsm import RegexFSM
-from outlines.fsm.json_schema import build_regex_from_schema
 from functools import lru_cache
 from typing import List, Optional, DefaultDict
 import time
@@ -519,19 +517,6 @@ class GrammarLogitProcessor(LogitsProcessor):
         if fsm_grammar_state == -1:
             return fsm_grammar_state
         return fsm.next_state(fsm_grammar_state, next_token_id)
-
-    # TODO: move grammar compilation into the router
-    @staticmethod
-    @lru_cache(maxsize=32, typed=True)
-    def _cached_compile_fsm(grammar_type, schema, tokenizer):
-        start_time = time.time()
-        if grammar_type == GrammarType.GRAMMAR_TYPE_JSON:
-            schema = build_regex_from_schema(schema)
-        elif grammar_type == GrammarType.GRAMMAR_TYPE_REGEX:
-            pass  # schema is already a regex just here for clarity
-        fsm = RegexFSM(schema, tokenizer)
-        logger.debug(f"Compiled FSM in {time.time() - start_time:.2f}s")
-        return fsm
 
     @staticmethod
     @lru_cache(maxsize=32, typed=True)

--- a/server/text_generation_server/utils/logits_process.py
+++ b/server/text_generation_server/utils/logits_process.py
@@ -475,9 +475,19 @@ class GrammarLogitProcessor(LogitsProcessor):
     fsm_state: DefaultDict[int, int]
     fsm: RegexFSM
 
-    def __init__(self, tokenizer, device, grammar, grammar_type):
+    def __init__(self, tokenizer, device, grammar, grammar_type, states_to_token_maps):
         self.device = device
         self.tokenizer = GrammarLogitProcessor._cached_adapt_tokenizer(tokenizer)
+
+        # TODO: use the precompiled grammar here
+        self.states_to_token_maps = states_to_token_maps
+        precompiled_grammar = RegexFSM.precompiled(
+            states_to_token_maps=states_to_token_maps,
+            empty_token_ids=None,
+            vocabulary=None,
+            eos_token_id=None,
+        )
+
         self.fsm = GrammarLogitProcessor._cached_compile_fsm(
             grammar_type, grammar, self.tokenizer
         )
@@ -550,14 +560,37 @@ class GrammarLogitProcessor(LogitsProcessor):
 
 
 class HeterogeneousGrammarLogitProcessor(LogitsProcessor):
-    def __init__(self, tokenizer, device, grammars, grammar_types):
+    def __init__(
+        self, tokenizer, device, grammars, grammar_types, states_to_token_maps
+    ):
         self.device = device
         self.tokenizer = GrammarLogitProcessor._cached_adapt_tokenizer(tokenizer)
         self.fsms = []
+
         for grammar, grammar_type in zip(grammars, grammar_types):
-            fsm = GrammarLogitProcessor._cached_compile_fsm(
-                grammar_type, grammar, self.tokenizer
+            start_states = states_to_token_maps[0].start_states
+            tokens = states_to_token_maps[0].tokens
+            end_states = states_to_token_maps[0].end_states
+
+            _states_to_token_maps = {}
+            for i in range(len(start_states)):
+                if start_states[i] in _states_to_token_maps:
+                    _states_to_token_maps[start_states[i]][tokens[i]] = end_states[i]
+                else:
+                    _states_to_token_maps[start_states[i]] = {tokens[i]: end_states[i]}
+
+            # TODO: cleanup how precompiled grammars are handled
+            precompiled_grammar = RegexFSM.precompiled(
+                states_to_token_maps=_states_to_token_maps,
+                empty_token_ids=None,
+                vocabulary=list(tokenizer.get_vocab().values()),
+                eos_token_id=self.tokenizer.eos_token_id,
             )
+            # fsm = GrammarLogitProcessor._cached_compile_fsm(
+            #     grammar_type, grammar, self.tokenizer
+            # )
+
+            fsm = precompiled_grammar
             self.fsms.append(fsm)
 
     def __call__(

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple
 import math
 import torch
 from text_generation_server.pb import generate_pb2
-from text_generation_server.pb.generate_pb2 import FinishReason, GrammarType
+from text_generation_server.pb.generate_pb2 import FinishReason
 from text_generation_server.utils.logits_process import (
     FrequencyPenaltyLogitsProcessor,
     GrammarLogitProcessor,

--- a/server/text_generation_server/utils/tokens.py
+++ b/server/text_generation_server/utils/tokens.py
@@ -54,7 +54,7 @@ class NextTokenChooser:
         )
         self.grammar_processor = (
             GrammarLogitProcessor(tokenizer, device, states_to_token_maps)
-            if states_to_token_maps
+            if len(states_to_token_maps.start_states) > 0
             else None
         )
         self.tokenizer = tokenizer
@@ -264,7 +264,7 @@ class HeterogeneousNextTokenChooser:
 
         self.grammar_processor = (
             HeterogeneousGrammarLogitProcessor(tokenizer, device, states_to_token_maps)
-            if any(states_to_token_maps)
+            if any([len(x.start_states) > 0 for x in states_to_token_maps])
             else None
         )
 
@@ -434,10 +434,13 @@ class HeterogeneousNextTokenChooser:
         self.seeds = [self.seeds[i] for i in indices]
         self.do_sample = [self.do_sample[i] for i in indices]
 
+        new_states_to_token_maps = []
         new_fsm_grammar_states = []
         for i in indices:
+            new_states_to_token_maps.append(self.states_to_token_maps[i])
             new_fsm_grammar_states.append(self.fsm_grammar_states[i])
 
+        self.states_to_token_maps = new_states_to_token_maps
         self.fsm_grammar_states = new_fsm_grammar_states
 
         if any(self.do_sample):


### PR DESCRIPTION
WIP

This PR is aims to move the compilation of grammars to the router. This should improve performance and remove work from the server. Just opening a PR for visibility/feedback

Currently this PR uses py03 to create grammar workers in the validator and can parse and compile them into a state map. Work is still needed to make use of the state map on the server side and remove existing grammar compilation code.

- [X] load outlines via py03
- [X] compile object to regex
- [X] compile regex to state map
- [X] pass statemap to server via grpc
- [x] replace grammar parse with state map

**unknowns
- how much does this improve performance?