### PR TITLE
chore: update `outlines` function call to new name

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -34,7 +34,7 @@ peft = { version = "^0.9.0", optional = true }
 torch = { version = "^2.1.1", optional = true }
 scipy = "^1.11.1"
 pillow = "^10.0.0"
-outlines= { version = "^0.0.27", optional = true }
+outlines= { version = "^0.0.32", optional = true }
 
 [tool.poetry.extras]
 torch = ["torch"]

--- a/server/text_generation_server/utils/logits_process.py
+++ b/server/text_generation_server/utils/logits_process.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 from text_generation_server.pb.generate_pb2 import GrammarType
 
 from outlines.fsm.fsm import RegexFSM
-from outlines.fsm.json_schema import build_regex_from_object
+from outlines.fsm.json_schema import build_regex_from_schema
 from functools import lru_cache
 from typing import List, Optional, DefaultDict
 import time
@@ -512,7 +512,7 @@ class GrammarLogitProcessor(LogitsProcessor):
     def _cached_compile_fsm(grammar_type, schema, tokenizer):
         start_time = time.time()
         if grammar_type == GrammarType.GRAMMAR_TYPE_JSON:
-            schema = build_regex_from_object(schema)
+            schema = build_regex_from_schema(schema)
         elif grammar_type == GrammarType.GRAMMAR_TYPE_REGEX:
             pass  # schema is already a regex just here for clarity
         fsm = RegexFSM(schema, tokenizer)


### PR DESCRIPTION
First of all really lovely project 💯 

This issue has been introduced since outlines version 0.32
With this pull request https://github.com/outlines-dev/outlines/pull/556
It changes the function name from
`build_regex_from_object` to `build_regex_from_schema`.
This leads to an error in newer docker containers when starting tgi.


I did not update the poetry.lock file as there is a forced local installation of `outlines` here: https://github.com/huggingface/text-generation-inference/blob/0d72af5ab01a5b1dabd5beda953403d63b1886e0/server/Makefile#L26

To mitigate it currently in newer docker containers, just run:

```bash
pip install outlines==0.0.31
```