### PR TITLE
Dev/mask ldconfig output v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,5 +250,7 @@ ENTRYPOINT ["./entrypoint.sh"]
 # Final image
 FROM base
 
-ENTRYPOINT ["text-generation-launcher"]
+COPY ./tgi-entrypoint.sh /tgi-entrypoint.sh
+
+ENTRYPOINT ["/tgi-entrypoint.sh"]
 CMD ["--json-output"]

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1209,16 +1209,6 @@ fn terminate(process_name: &str, mut process: Child, timeout: Duration) -> io::R
 }
 
 fn main() -> Result<(), LauncherError> {
-    match Command::new("ldconfig").spawn() {
-        Ok(_) => {}
-        Err(err) => {
-            tracing::warn!(
-                "Unable to refresh ldconfig cache. Skipping (useless in most cases). Details {:?}",
-                err
-            )
-        }
-    }
-
     // Pattern match configuration
     let args: Args = Args::parse();
 

--- a/tgi-entrypoint.sh
+++ b/tgi-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ldconfig 2>/dev/null || echo 'unable to refresh ld cache, not a big deal in most cases'
+
+text-generation-launcher $@


### PR DESCRIPTION
wrap text-generation-launcher in docker image
mask ldconfig failures to user (no need in most cases anyway)