### PR TITLE
fix: fp8 dimensions size

### DIFF
--- a/server/text_generation_server/utils/layers.py
+++ b/server/text_generation_server/utils/layers.py
@@ -212,6 +212,8 @@ class Fp8Linear(nn.Module):
         self.bias = bias if bias is not None else None
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if (bsz := input.shape[0]) & 15:
+            input = F.pad(input,(0, 0, 0, 16 - (bsz & 15)))
         qinput, scale = fp8_quantize(input)
         output, _ = torch._scaled_mm(
             qinput,
@@ -221,7 +223,7 @@ class Fp8Linear(nn.Module):
             scale_b=self.scale,
             bias=self.bias,
         )
-        return output
+        return output[:bsz]
 
 
 class Linear8bitLt(nn.Module):


### PR DESCRIPTION
fp8 quantization currently limited to tensors with shapes where both dimensions are divisible by 16.

Hello @Narsil , 
when I was using fp8 quantize on H100, I get some error which is size is not divisible by 16, 

check  `filter_out_small_unaligned_layers` https://github.com/pytorch-labs/float8_experimental/blob/ac065d09a6259574a85027edc84eb647dc6c90c2/float8_experimental/float8_linear_utils.py#L82-L93

they check layers size, this thing is when user requests is not batched by 16 this make pad for dummy requests

# What does this PR do?

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil