### PR TITLE
feat: add one line quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ server/exllama_kernels/exllama_kernels/hip_func/
 *_hip.cuh
 server/exllama_kernels/exllama_kernels/hip_buffers.cuh
 server/exllama_kernels/exllama_kernels/exllama_ext_hip.cpp
+
+# ignore default docker directory
+data/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ Text Generation Inference (TGI) is a toolkit for deploying and serving Large Lan
 
 ## Get Started
 
+### Quick Start ⚡️
+
+The fastest way to get started is to use the quickstart script. This script simplifies the docker and nvidia container toolkit installation process. It also installs the latest version of the text-generation-inference container and runs it with a default model.
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf \
+    https://raw.githubusercontent.com/huggingface/text-generation-inference/quickstart.sh \
+    | bash
+```
+![best practice script review](https://img.shields.io/badge/Best_Practice-yellow) Always review the contents of a script before running it.
+
+
 ### Docker
 
 For a detailed starting guide, please see the [Quick Tour](https://huggingface.co/docs/text-generation-inference/quicktour). The easiest way of getting started is using the official Docker container:

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -35,4 +35,4 @@ model="HuggingFaceH4/zephyr-7b-beta"
 volume="$PWD/data"
 
 # Run the Docker container in interactive mode to allow CTRL+C to stop the container
-docker run -it --gpus all --shm-size 1g -p 8080:80 -v "$volume:/data" ghcr.io/huggingface/text-generation-inference:2.0 --model-id "$model"
+docker run -it --gpus all --shm-size 1g -p 8080:80 -v "$volume:/data" ghcr.io/huggingface/text-generation-inference:latest --model-id "$model"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+  # Install Docker based on the OS
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Ubuntu/Debian-based systems
+    sudo apt-get update && sudo apt-get install -y docker.io
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS (using Homebrew)
+    brew install --cask docker
+  elif [[ "$OSTYPE" == "msys"* ]]; then
+    # Windows (using Chocolatey)
+    choco install docker-desktop
+  else
+    echo "Unsupported OS: $OSTYPE"
+    exit 1
+  fi
+fi
+
+# Install NVIDIA Container Toolkit (only if on Linux)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # Currently, NVIDIA Container Toolkit does not support macOS, so warn the user.
+  echo "NVIDIA Container Toolkit is not available for macOS."
+  exit 1
+elif [[ "$OSTYPE" == "msys"* ]]; then
+  # Currently, NVIDIA Container Toolkit does not support Windows directly.
+  echo "NVIDIA Container Toolkit is not available for Windows. Ensure Docker Desktop WSL 2 backend is enabled."
+fi
+
+# Set variables for the Docker container
+model="HuggingFaceH4/zephyr-7b-beta"
+volume="$PWD/data"
+
+# Run the Docker container in interactive mode to allow CTRL+C to stop the container
+docker run -it --gpus all --shm-size 1g -p 8080:80 -v "$volume:/data" ghcr.io/huggingface/text-generation-inference:2.0 --model-id "$model"


### PR DESCRIPTION
This PR adds a simple quickstart file that conditionally installs `docker` and `nvidia-container-toolkit` before fetching the TGI docker container and running it with `HuggingFaceH4/zephyr-7b-beta`

It can be run with 

```bash
bash quickstart.sh
```

additional TGI can be installed without cloning the repo

```bash
# using this branch
curl --proto '=https' --tlsv1.2 -sSf \
    https://raw.githubusercontent.com/huggingface/text-generation-inference/add-quickstart-script/quickstart.sh \
    | bash

# if merged
curl --proto '=https' --tlsv1.2 -sSf \
    https://raw.githubusercontent.com/huggingface/text-generation-inference/quickstart.sh \
    | bash
```