### PR TITLE
feat: include token in client test like server tests

### DIFF
--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -22,4 +22,5 @@ jobs:
       - name: Run tests
         run: |
           pip install pytest pytest-asyncio
+          export HUGGING_FACE_HUB_TOKEN=${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           make python-client-tests


### PR DESCRIPTION
This PR simply includes the HF token in the client tests similar to how it's included in the server tests. This helps avoid CI failure due to rate limiting