### PR TITLE
fix: use path inside of speculator config

### DIFF
--- a/server/text_generation_server/layers/medusa.py
+++ b/server/text_generation_server/layers/medusa.py
@@ -111,10 +111,10 @@ class MedusaHeadV2(nn.Module):
         from safetensors import safe_open
         import json
 
-        speculator = config.speculator
+        speculator_path = config.speculator["path"]
 
-        medusa_config = str(Path(speculator) / "config.json")
-        filename = str(Path(speculator) / "medusa_lm_head.safetensors")
+        medusa_config = str(Path(speculator_path) / "config.json")
+        filename = str(Path(speculator_path) / "medusa_lm_head.safetensors")
 
         with open(medusa_config, "r") as f:
             medusa_config = json.load(f)


### PR DESCRIPTION
This PR access the path on the speculator similar to `MLPSpeculatorHead.load` and `MedusaHeadV1.load` 


these changes resolves this error locally when loading a `MedusaHeadV2`
```
TypeError: expected str, bytes or os.PathLike object, not dict
```