### PR TITLE
implement Open Inference Protocol endpoints

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -58,3 +58,4 @@ vergen = { version = "8.2.5", features = ["build", "git", "gitcl"] }
 default = ["ngrok"]
 ngrok = ["dep:ngrok"]
 google = []
+kserve = []

--- a/router/src/kserve.rs
+++ b/router/src/kserve.rs
@@ -1,0 +1,247 @@
+use crate::{
+    default_parameters,
+    server::{generate_internal, ComputeType},
+    Deserialize, ErrorResponse, GenerateParameters, GenerateRequest, Infer, Serialize, ToSchema,
+};
+use axum::extract::{Extension, Path};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use futures::stream::FuturesUnordered;
+use futures::TryStreamExt;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct OutputChunk {
+    pub name: String,
+    pub shape: Vec<usize>,
+    pub datatype: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct InferenceOutput {
+    pub id: String,
+    pub outputs: Vec<OutputChunk>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub(crate) struct InferenceRequest {
+    pub id: String,
+    #[serde(default = "default_parameters")]
+    pub parameters: GenerateParameters,
+    pub inputs: Vec<Input>,
+    pub outputs: Vec<Output>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub(crate) struct Input {
+    pub name: String,
+    pub shape: Vec<usize>,
+    pub datatype: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub(crate) struct Output {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct LiveResponse {
+    pub live: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ReadyResponse {
+    pub live: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct MetadataServerResponse {
+    pub name: String,
+    pub version: String,
+    pub extensions: Vec<String>,
+}
+
+// Routes
+
+#[utoipa::path(
+    post,
+    tag = "Text Generation Inference",
+    path = "/v2/health/live",
+    responses(
+        (status = 200, description = "Service is live", body = LiveReponse),
+        (status = 404, description = "Service not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
+    )
+)]
+pub async fn kserve_health_live() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let data = LiveResponse { live: true };
+    Ok((HeaderMap::new(), Json(data)).into_response())
+}
+
+#[utoipa::path(
+    post,
+    tag = "Text Generation Inference",
+    path = "/v2/health/ready",
+    responses(
+        (status = 200, description = "Service is ready", body = ReadyResponse),
+        (status = 404, description = "Service not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
+    )
+)]
+pub async fn kserve_health_ready() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let data = ReadyResponse { live: true };
+    Ok((HeaderMap::new(), Json(data)).into_response())
+}
+
+#[utoipa::path(
+    get,
+    tag = "Text Generation Inference",
+    path = "/v2",
+    responses(
+        (status = 200, description = "Metadata retrieved", body = MetadataServerResponse),
+        (status = 404, description = "Service not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
+    )
+)]
+pub async fn kerve_server_metadata() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let data = MetadataServerResponse {
+        name: "text-generation-inference".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        extensions: vec![
+            "health".to_string(),
+            "models".to_string(),
+            "metrics".to_string(),
+        ],
+    };
+    Ok((HeaderMap::new(), Json(data)).into_response())
+}
+
+#[utoipa::path(
+    get,
+    tag = "Text Generation Inference",
+    path = "/v2/models/{model_name}/versions/{model_version}",
+    responses(
+        (status = 200, description = "Model version metadata retrieved", body = MetadataServerResponse),
+        (status = 404, description = "Model or version not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
+    )
+)]
+pub async fn kserve_model_metadata(
+    Path((model_name, model_version)): Path<(String, String)>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let data = MetadataServerResponse {
+        name: model_name,
+        version: model_version,
+        extensions: vec!["infer".to_string(), "ready".to_string()],
+    };
+    Ok((HeaderMap::new(), Json(data)).into_response())
+}
+
+#[utoipa::path(
+    post,
+    tag = "Text Generation Inference",
+    path = "/v2/models/{model_name}/versions/{model_version}/infer",
+    request_body = Json<InferenceRequest>,
+    responses(
+        (status = 200, description = "Inference executed successfully", body = InferenceOutput),
+        (status = 404, description = "Model or version not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
+    )
+)]
+pub async fn kserve_model_infer(
+    infer: Extension<Infer>,
+    Extension(compute_type): Extension<ComputeType>,
+    Json(payload): Json<InferenceRequest>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let id = payload.id.clone();
+    let str_inputs = payload
+        .inputs
+        .iter()
+        .map(|input| {
+            std::str::from_utf8(&input.data).map_err(|e| {
+                (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(ErrorResponse {
+                        error: e.to_string(),
+                        error_type: "utf8".to_string(),
+                    }),
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if str_inputs.len() != payload.outputs.len() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse {
+                error: "Inputs and outputs length mismatch".to_string(),
+                error_type: "length mismatch".to_string(),
+            }),
+        ));
+    }
+
+    let output_chunks = str_inputs
+        .iter()
+        .zip(&payload.outputs)
+        .map(|(str_input, output)| {
+            let generate_request = GenerateRequest {
+                inputs: str_input.to_string(),
+                parameters: payload.parameters.clone(),
+            };
+            let infer = infer.clone();
+            let compute_type = compute_type.clone();
+            let span = tracing::Span::current();
+            async move {
+                generate_internal(infer, compute_type, Json(generate_request), span)
+                    .await
+                    .map(|(_, Json(generation))| {
+                        let generation_as_bytes = generation.generated_text.as_bytes().to_vec();
+                        OutputChunk {
+                            name: output.name.clone(),
+                            shape: vec![1, generation_as_bytes.len()],
+                            datatype: "BYTES".to_string(),
+                            data: generation_as_bytes,
+                        }
+                    })
+                    .map_err(|_| {
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(ErrorResponse {
+                                error: "Incomplete generation".into(),
+                                error_type: "Incomplete generation".into(),
+                            }),
+                        )
+                    })
+            }
+        })
+        .collect::<FuturesUnordered<_>>()
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let inference_output = InferenceOutput {
+        id: id.clone(),
+        outputs: output_chunks,
+    };
+
+    Ok((HeaderMap::new(), Json(inference_output)).into_response())
+}
+
+#[utoipa::path(
+    get,
+    tag = "Text Generation Inference",
+    path = "/v2/models/{model_name}/versions/{model_version}/ready",
+    responses(
+        (status = 200, description = "Model version is ready", body = ReadyResponse),
+        (status = 404, description = "Model or version not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
+    )
+)]
+pub async fn kserve_model_metadata_ready(
+    Path((_model_name, _model_version)): Path<(String, String)>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let data = ReadyResponse { live: true };
+    Ok((HeaderMap::new(), Json(data)).into_response())
+}

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -4,68 +4,15 @@ mod infer;
 pub mod server;
 mod validation;
 
+#[cfg(feature = "kserve")]
+mod kserve;
+
+use infer::{Infer, InferError, InferStreamResponse};
+use queue::{Entry, Queue};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use utoipa::ToSchema;
 use validation::Validation;
-
-#[cfg(feature = "kserve")]
-mod kserve {
-    use super::*;
-
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub struct OutputChunk {
-        pub name: String,
-        pub shape: Vec<usize>,
-        pub datatype: String,
-        pub data: Vec<u8>,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub struct InferenceOutput {
-        pub id: String,
-        pub outputs: Vec<OutputChunk>,
-    }
-
-    #[derive(Debug, Deserialize, ToSchema)]
-    pub(crate) struct InferenceRequest {
-        pub id: String,
-        #[serde(default = "default_parameters")]
-        pub parameters: GenerateParameters,
-        pub inputs: Vec<Input>,
-        pub outputs: Vec<Output>,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub(crate) struct Input {
-        pub name: String,
-        pub shape: Vec<usize>,
-        pub datatype: String,
-        pub data: Vec<u8>,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub(crate) struct Output {
-        pub name: String,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub struct LiveReponse {
-        pub live: bool,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub struct ReadyResponse {
-        pub live: bool,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub struct MetadataServerResponse {
-        pub name: String,
-        pub version: String,
-        pub extensions: Vec<String>,
-    }
-}
 
 /// Type alias for generation responses
 pub(crate) type GenerateStreamResponse = (

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 use utoipa::ToSchema;
 use validation::Validation;
 
+#[cfg(feature = "kserve")]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct OutputChunk {
     name: String,
@@ -17,42 +18,51 @@ pub struct OutputChunk {
     data: Vec<u8>,
 }
 
+#[cfg(feature = "kserve")]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct InferenceOutput {
     id: String,
     outputs: Vec<OutputChunk>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct InferenceRequest {
+#[cfg(feature = "kserve")]
+#[derive(Debug, Deserialize, ToSchema)]
+pub(crate) struct InferenceRequest {
     pub id: String,
+    #[serde(default = "default_parameters")]
+    pub parameters: GenerateParameters,
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
 }
 
+#[cfg(feature = "kserve")]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct Input {
+pub(crate) struct Input {
     pub name: String,
     pub shape: Vec<usize>,
     pub datatype: String,
     pub data: Vec<u8>,
 }
 
+#[cfg(feature = "kserve")]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct Output {
+pub(crate) struct Output {
     pub name: String,
 }
 
+#[cfg(feature = "kserve")]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct LiveReponse {
     pub live: bool,
 }
 
+#[cfg(feature = "kserve")]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ReadyResponse {
     pub live: bool,
 }
 
+#[cfg(feature = "kserve")]
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct MetadataServerResponse {
     pub name: String,

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -10,6 +10,40 @@ use utoipa::ToSchema;
 use validation::Validation;
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct OutputChunk {
+    name: String,
+    shape: Vec<usize>,
+    datatype: String,
+    data: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct InferenceOutput {
+    id: String,
+    outputs: Vec<OutputChunk>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct InferenceRequest {
+    pub id: String,
+    pub inputs: Vec<Input>,
+    pub outputs: Vec<Output>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct Input {
+    pub name: String,
+    pub shape: Vec<usize>,
+    pub datatype: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct Output {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct LiveReponse {
     pub live: bool,
 }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -10,64 +10,61 @@ use utoipa::ToSchema;
 use validation::Validation;
 
 #[cfg(feature = "kserve")]
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct OutputChunk {
-    name: String,
-    shape: Vec<usize>,
-    datatype: String,
-    data: Vec<u8>,
-}
+mod kserve {
+    use super::*;
 
-#[cfg(feature = "kserve")]
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct InferenceOutput {
-    id: String,
-    outputs: Vec<OutputChunk>,
-}
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
+    pub struct OutputChunk {
+        pub name: String,
+        pub shape: Vec<usize>,
+        pub datatype: String,
+        pub data: Vec<u8>,
+    }
 
-#[cfg(feature = "kserve")]
-#[derive(Debug, Deserialize, ToSchema)]
-pub(crate) struct InferenceRequest {
-    pub id: String,
-    #[serde(default = "default_parameters")]
-    pub parameters: GenerateParameters,
-    pub inputs: Vec<Input>,
-    pub outputs: Vec<Output>,
-}
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
+    pub struct InferenceOutput {
+        pub id: String,
+        pub outputs: Vec<OutputChunk>,
+    }
 
-#[cfg(feature = "kserve")]
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub(crate) struct Input {
-    pub name: String,
-    pub shape: Vec<usize>,
-    pub datatype: String,
-    pub data: Vec<u8>,
-}
+    #[derive(Debug, Deserialize, ToSchema)]
+    pub(crate) struct InferenceRequest {
+        pub id: String,
+        #[serde(default = "default_parameters")]
+        pub parameters: GenerateParameters,
+        pub inputs: Vec<Input>,
+        pub outputs: Vec<Output>,
+    }
 
-#[cfg(feature = "kserve")]
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub(crate) struct Output {
-    pub name: String,
-}
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
+    pub(crate) struct Input {
+        pub name: String,
+        pub shape: Vec<usize>,
+        pub datatype: String,
+        pub data: Vec<u8>,
+    }
 
-#[cfg(feature = "kserve")]
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct LiveReponse {
-    pub live: bool,
-}
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
+    pub(crate) struct Output {
+        pub name: String,
+    }
 
-#[cfg(feature = "kserve")]
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct ReadyResponse {
-    pub live: bool,
-}
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
+    pub struct LiveReponse {
+        pub live: bool,
+    }
 
-#[cfg(feature = "kserve")]
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct MetadataServerResponse {
-    pub name: String,
-    pub version: String,
-    pub extensions: Vec<String>,
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
+    pub struct ReadyResponse {
+        pub live: bool,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
+    pub struct MetadataServerResponse {
+        pub name: String,
+        pub version: String,
+        pub extensions: Vec<String>,
+    }
 }
 
 /// Type alias for generation responses

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -9,6 +9,30 @@ use tracing::warn;
 use utoipa::ToSchema;
 use validation::Validation;
 
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct LiveReponse {
+    pub live: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ReadyResponse {
+    pub live: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct MetadataServerResponse {
+    pub name: String,
+    pub version: String,
+    pub extensions: Vec<String>,
+}
+
+/// Type alias for generation responses
+pub(crate) type GenerateStreamResponse = (
+    OwnedSemaphorePermit,
+    u32, // input_length
+    UnboundedReceiverStream<Result<InferStreamResponse, InferError>>,
+);
+
 #[derive(Clone, Deserialize, ToSchema)]
 pub(crate) struct VertexInstance {
     #[schema(example = "What is Deep Learning?")]

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -7,19 +7,10 @@ mod validation;
 #[cfg(feature = "kserve")]
 mod kserve;
 
-use infer::{Infer, InferError, InferStreamResponse};
-use queue::{Entry, Queue};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use utoipa::ToSchema;
 use validation::Validation;
-
-/// Type alias for generation responses
-pub(crate) type GenerateStreamResponse = (
-    OwnedSemaphorePermit,
-    u32, // input_length
-    UnboundedReceiverStream<Result<InferStreamResponse, InferError>>,
-);
 
 #[derive(Clone, Deserialize, ToSchema)]
 pub(crate) struct VertexInstance {

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -4,7 +4,6 @@ use crate::infer::v2::SchedulerV2;
 use crate::infer::v3::SchedulerV3;
 use crate::infer::{HealthCheck, Scheduler};
 use crate::infer::{Infer, InferError, InferResponse, InferStreamResponse, ToolGrammar};
-use crate::health::Health;
 #[cfg(feature = "kserve")]
 use crate::kserve::{
     kerve_server_metadata, kserve_health_live, kserve_health_ready, kserve_model_infer,

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -4,6 +4,12 @@ use crate::infer::v2::SchedulerV2;
 use crate::infer::v3::SchedulerV3;
 use crate::infer::{HealthCheck, Scheduler};
 use crate::infer::{Infer, InferError, InferResponse, InferStreamResponse, ToolGrammar};
+use crate::health::Health;
+#[cfg(feature = "kserve")]
+use crate::kserve::{
+    InferenceOutput, InferenceRequest, LiveReponse, MetadataServerResponse, OutputChunk,
+    ReadyResponse,
+};
 use crate::validation::ValidationError;
 use crate::{
     BestOfSequence, Details, ErrorResponse, FinishReason, GenerateParameters, GenerateRequest,
@@ -18,11 +24,6 @@ use crate::{
     CompletionRequest, DeltaToolCall, Function, Tool, VertexRequest, VertexResponse,
 };
 use crate::{FunctionDefinition, ToolCall, ToolType};
-#[cfg(feature = "kserve")]
-use crate::{
-    InferenceOutput, InferenceRequest, LiveReponse, MetadataServerResponse, OutputChunk,
-    ReadyResponse,
-};
 use async_stream::__private::AsyncStream;
 use axum::extract::Extension;
 #[cfg(feature = "kserve")]
@@ -1382,13 +1383,12 @@ async fn metrics(prom_handle: Extension<PrometheusHandle>) -> String {
     tag = "Text Generation Inference",
     path = "/v2/health/live",
     responses(
-    (status = 200, description = "Live response", body = LiveReponse),
-    (status = 404, description = "No response", body = ErrorResponse,
-    example = json ! ({"error": "No response"})),
+        (status = 200, description = "Service is live", body = LiveReponse),
+        (status = 404, description = "Service not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
     )
-    )]
-// https://github.com/kserve/open-inference-protocol/blob/main/specification/protocol/inference_rest.md
-async fn get_v2_health_live() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+)]
+async fn kserve_health_live() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let data = LiveReponse { live: true };
     Ok((HeaderMap::new(), Json(data)).into_response())
 }
@@ -1399,12 +1399,12 @@ async fn get_v2_health_live() -> Result<Response, (StatusCode, Json<ErrorRespons
     tag = "Text Generation Inference",
     path = "/v2/health/ready",
     responses(
-    (status = 200, description = "Ready response", body = ReadyResponse),
-    (status = 404, description = "No response", body = ErrorResponse,
-    example = json ! ({"error": "No response"})),
+        (status = 200, description = "Service is ready", body = ReadyResponse),
+        (status = 404, description = "Service not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
     )
-    )]
-async fn get_v2_health_ready() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+)]
+async fn kserve_health_ready() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let data = ReadyResponse { live: true };
     Ok((HeaderMap::new(), Json(data)).into_response())
 }
@@ -1415,12 +1415,12 @@ async fn get_v2_health_ready() -> Result<Response, (StatusCode, Json<ErrorRespon
     tag = "Text Generation Inference",
     path = "/v2",
     responses(
-    (status = 200, description = "Metadata response", body = MetadataServerResponse),
-    (status = 404, description = "No response", body = ErrorResponse,
-    example = json ! ({"error": "No response"})),
+        (status = 200, description = "Metadata retrieved", body = MetadataServerResponse),
+        (status = 404, description = "Service not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
     )
-    )]
-async fn get_v2() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+)]
+async fn kerve_server_metadata() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let data = MetadataServerResponse {
         name: "text-generation-inference".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -1439,12 +1439,12 @@ async fn get_v2() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     tag = "Text Generation Inference",
     path = "/v2/models/{model_name}/versions/{model_version}",
     responses(
-    (status = 200, description = "Model ready response", body = MetadataServerResponse),
-    (status = 404, description = "No response", body = ErrorResponse,
-    example = json ! ({"error": "No response"})),
+        (status = 200, description = "Model version metadata retrieved", body = MetadataServerResponse),
+        (status = 404, description = "Model or version not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
     )
-    )]
-async fn get_v2_models_model_name_versions_model_version(
+)]
+async fn kserve_model_metadata(
     Path((model_name, model_version)): Path<(String, String)>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let data = MetadataServerResponse {
@@ -1462,12 +1462,12 @@ async fn get_v2_models_model_name_versions_model_version(
     path = "/v2/models/{model_name}/versions/{model_version}/infer",
     request_body = Json<InferenceRequest>,
     responses(
-    (status = 200, description = "Inference response", body = InferenceOutput),
-    (status = 404, description = "No response", body = ErrorResponse,
-    example = json ! ({"error": "No response"})),
+        (status = 200, description = "Inference executed successfully", body = InferenceOutput),
+        (status = 404, description = "Model or version not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
     )
-    )]
-async fn post_v2_models_model_name_versions_model_version_infer(
+)]
+async fn kserve_model_infer(
     infer: Extension<Infer>,
     Extension(compute_type): Extension<ComputeType>,
     Json(payload): Json<InferenceRequest>,
@@ -1551,12 +1551,12 @@ async fn post_v2_models_model_name_versions_model_version_infer(
     tag = "Text Generation Inference",
     path = "/v2/models/{model_name}/versions/{model_version}/ready",
     responses(
-    (status = 200, description = "Model ready response", body = ReadyResponse),
-    (status = 404, description = "No response", body = ErrorResponse,
-    example = json ! ({"error": "No response"})),
+        (status = 200, description = "Model version is ready", body = ReadyResponse),
+        (status = 404, description = "Model or version not found", body = ErrorResponse,
+            example = json!({"error": "No response"}))
     )
-    )]
-async fn get_v2_models_model_name_versions_model_version_ready(
+)]
+async fn kserve_model_metadata_ready(
     Path((_model_name, _model_version)): Path<(String, String)>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let data = ReadyResponse { live: true };
@@ -1928,12 +1928,12 @@ pub async fn run(
                 #[derive(OpenApi)]
                 #[openapi(
                     paths(
-                        post_v2_models_model_name_versions_model_version_infer,
-                        get_v2_health_live,
-                        get_v2_health_ready,
-                        get_v2,
-                        get_v2_models_model_name_versions_model_version,
-                        get_v2_models_model_name_versions_model_version_ready,
+                        kserve_model_infer,
+                        kserve_health_live,
+                        kserve_health_ready,
+                        kerve_server_metadata,
+                        kserve_model_metadata,
+                        kserve_model_metadata_ready,
                     ),
                     components(schemas(LiveReponse, ReadyResponse, MetadataServerResponse,))
                 )]
@@ -2002,18 +2002,18 @@ pub async fn run(
         app = app
             .route(
                 "/v2/models/:model_name/versions/:model_version/infer",
-                post(post_v2_models_model_name_versions_model_version_infer),
+                post(kserve_model_infer),
             )
             .route(
                 "/v2/models/:model_name/versions/:model_version",
-                get(get_v2_models_model_name_versions_model_version),
+                get(kserve_model_metadata),
             )
-            .route("/v2/health/ready", get(get_v2_health_ready))
-            .route("/v2/health/live", get(get_v2_health_live))
-            .route("/v2", get(get_v2))
+            .route("/v2/health/ready", get(kserve_health_ready))
+            .route("/v2/health/live", get(kserve_health_live))
+            .route("/v2", get(kerve_server_metadata))
             .route(
                 "/v2/models/:model_name/versions/:model_version/ready",
-                get(get_v2_models_model_name_versions_model_version_ready),
+                get(kserve_model_metadata_ready),
             );
     }
 

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -7,8 +7,8 @@ use crate::infer::{Infer, InferError, InferResponse, InferStreamResponse, ToolGr
 use crate::health::Health;
 #[cfg(feature = "kserve")]
 use crate::kserve::{
-    InferenceOutput, InferenceRequest, LiveReponse, MetadataServerResponse, OutputChunk,
-    ReadyResponse,
+    kerve_server_metadata, kserve_health_live, kserve_health_ready, kserve_model_infer,
+    kserve_model_metadata, kserve_model_metadata_ready,
 };
 use crate::validation::ValidationError;
 use crate::{
@@ -26,8 +26,6 @@ use crate::{
 use crate::{FunctionDefinition, ToolCall, ToolType};
 use async_stream::__private::AsyncStream;
 use axum::extract::Extension;
-#[cfg(feature = "kserve")]
-use axum::extract::Path;
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
@@ -180,7 +178,7 @@ async fn generate(
     generate_internal(infer, ComputeType(compute_type), Json(req), span).await
 }
 
-async fn generate_internal(
+pub(crate) async fn generate_internal(
     infer: Extension<Infer>,
     ComputeType(compute_type): ComputeType,
     Json(req): Json<GenerateRequest>,
@@ -1377,192 +1375,6 @@ async fn metrics(prom_handle: Extension<PrometheusHandle>) -> String {
     prom_handle.render()
 }
 
-#[cfg(feature = "kserve")]
-#[utoipa::path(
-    post,
-    tag = "Text Generation Inference",
-    path = "/v2/health/live",
-    responses(
-        (status = 200, description = "Service is live", body = LiveReponse),
-        (status = 404, description = "Service not found", body = ErrorResponse,
-            example = json!({"error": "No response"}))
-    )
-)]
-async fn kserve_health_live() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
-    let data = LiveReponse { live: true };
-    Ok((HeaderMap::new(), Json(data)).into_response())
-}
-
-#[cfg(feature = "kserve")]
-#[utoipa::path(
-    post,
-    tag = "Text Generation Inference",
-    path = "/v2/health/ready",
-    responses(
-        (status = 200, description = "Service is ready", body = ReadyResponse),
-        (status = 404, description = "Service not found", body = ErrorResponse,
-            example = json!({"error": "No response"}))
-    )
-)]
-async fn kserve_health_ready() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
-    let data = ReadyResponse { live: true };
-    Ok((HeaderMap::new(), Json(data)).into_response())
-}
-
-#[cfg(feature = "kserve")]
-#[utoipa::path(
-    get,
-    tag = "Text Generation Inference",
-    path = "/v2",
-    responses(
-        (status = 200, description = "Metadata retrieved", body = MetadataServerResponse),
-        (status = 404, description = "Service not found", body = ErrorResponse,
-            example = json!({"error": "No response"}))
-    )
-)]
-async fn kerve_server_metadata() -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
-    let data = MetadataServerResponse {
-        name: "text-generation-inference".to_string(),
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        extensions: vec![
-            "health".to_string(),
-            "models".to_string(),
-            "metrics".to_string(),
-        ],
-    };
-    Ok((HeaderMap::new(), Json(data)).into_response())
-}
-
-#[cfg(feature = "kserve")]
-#[utoipa::path(
-    get,
-    tag = "Text Generation Inference",
-    path = "/v2/models/{model_name}/versions/{model_version}",
-    responses(
-        (status = 200, description = "Model version metadata retrieved", body = MetadataServerResponse),
-        (status = 404, description = "Model or version not found", body = ErrorResponse,
-            example = json!({"error": "No response"}))
-    )
-)]
-async fn kserve_model_metadata(
-    Path((model_name, model_version)): Path<(String, String)>,
-) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
-    let data = MetadataServerResponse {
-        name: model_name,
-        version: model_version,
-        extensions: vec!["infer".to_string(), "ready".to_string()],
-    };
-    Ok((HeaderMap::new(), Json(data)).into_response())
-}
-
-#[cfg(feature = "kserve")]
-#[utoipa::path(
-    post,
-    tag = "Text Generation Inference",
-    path = "/v2/models/{model_name}/versions/{model_version}/infer",
-    request_body = Json<InferenceRequest>,
-    responses(
-        (status = 200, description = "Inference executed successfully", body = InferenceOutput),
-        (status = 404, description = "Model or version not found", body = ErrorResponse,
-            example = json!({"error": "No response"}))
-    )
-)]
-async fn kserve_model_infer(
-    infer: Extension<Infer>,
-    Extension(compute_type): Extension<ComputeType>,
-    Json(payload): Json<InferenceRequest>,
-) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
-    let id = payload.id.clone();
-    let str_inputs = payload
-        .inputs
-        .iter()
-        .map(|input| {
-            std::str::from_utf8(&input.data).map_err(|e| {
-                (
-                    StatusCode::UNPROCESSABLE_ENTITY,
-                    Json(ErrorResponse {
-                        error: e.to_string(),
-                        error_type: "utf8".to_string(),
-                    }),
-                )
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    if str_inputs.len() != payload.outputs.len() {
-        return Err((
-            StatusCode::UNPROCESSABLE_ENTITY,
-            Json(ErrorResponse {
-                error: "Inputs and outputs length mismatch".to_string(),
-                error_type: "length mismatch".to_string(),
-            }),
-        ));
-    }
-
-    let output_chunks = str_inputs
-        .iter()
-        .zip(&payload.outputs)
-        .map(|(str_input, output)| {
-            let generate_request = GenerateRequest {
-                inputs: str_input.to_string(),
-                parameters: payload.parameters.clone(),
-            };
-            let infer = infer.clone();
-            let compute_type = compute_type.clone();
-            let span = tracing::Span::current();
-            async move {
-                generate_internal(infer, compute_type, Json(generate_request), span)
-                    .await
-                    .map(|(_, Json(generation))| {
-                        let generation_as_bytes = generation.generated_text.as_bytes().to_vec();
-                        OutputChunk {
-                            name: output.name.clone(),
-                            shape: vec![1, generation_as_bytes.len()],
-                            datatype: "BYTES".to_string(),
-                            data: generation_as_bytes,
-                        }
-                    })
-                    .map_err(|_| {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse {
-                                error: "Incomplete generation".into(),
-                                error_type: "Incomplete generation".into(),
-                            }),
-                        )
-                    })
-            }
-        })
-        .collect::<FuturesUnordered<_>>()
-        .try_collect::<Vec<_>>()
-        .await?;
-
-    let inference_output = InferenceOutput {
-        id: id.clone(),
-        outputs: output_chunks,
-    };
-
-    Ok((HeaderMap::new(), Json(inference_output)).into_response())
-}
-
-#[cfg(feature = "kserve")]
-#[utoipa::path(
-    get,
-    tag = "Text Generation Inference",
-    path = "/v2/models/{model_name}/versions/{model_version}/ready",
-    responses(
-        (status = 200, description = "Model version is ready", body = ReadyResponse),
-        (status = 404, description = "Model or version not found", body = ErrorResponse,
-            example = json!({"error": "No response"}))
-    )
-)]
-async fn kserve_model_metadata_ready(
-    Path((_model_name, _model_version)): Path<(String, String)>,
-) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
-    let data = ReadyResponse { live: true };
-    Ok((HeaderMap::new(), Json(data)).into_response())
-}
-
 #[derive(Clone, Debug)]
 pub(crate) struct ComputeType(String);
 
@@ -1903,50 +1715,58 @@ pub async fn run(
         docker_label: option_env!("DOCKER_LABEL"),
     };
 
-    // Define VertextApiDoc conditionally only if the "google" feature is enabled
-    let doc = {
-        #[cfg(feature = "google")]
-        {
-            use crate::VertexInstance;
+    #[allow(unused_mut)] // mut is needed for conditional compilation
+    let mut doc = ApiDoc::openapi();
 
-            #[derive(OpenApi)]
-            #[openapi(
-                paths(vertex_compatibility),
-                components(schemas(VertexInstance, VertexRequest, VertexResponse))
-            )]
-            struct VertextApiDoc;
+    #[cfg(feature = "google")]
+    {
+        use crate::VertexInstance;
 
-            let mut doc = ApiDoc::openapi();
-            doc.merge(VertextApiDoc::openapi());
-            doc
-        }
-        #[cfg(not(feature = "google"))]
-        {
-            // Define KServeApiDoc conditionally only if the "kserve" feature is enabled
-            #[cfg(feature = "kserve")]
-            {
-                #[derive(OpenApi)]
-                #[openapi(
-                    paths(
-                        kserve_model_infer,
-                        kserve_health_live,
-                        kserve_health_ready,
-                        kerve_server_metadata,
-                        kserve_model_metadata,
-                        kserve_model_metadata_ready,
-                    ),
-                    components(schemas(LiveReponse, ReadyResponse, MetadataServerResponse,))
-                )]
-                struct KServeApiDoc;
+        #[derive(OpenApi)]
+        #[openapi(
+            paths(vertex_compatibility),
+            components(schemas(VertexInstance, VertexRequest, VertexResponse))
+        )]
+        struct VertexApiDoc;
 
-                let mut doc = ApiDoc::openapi();
-                doc.merge(KServeApiDoc::openapi());
-                doc
-            }
-            #[cfg(not(feature = "kserve"))]
-            ApiDoc::openapi()
-        }
-    };
+        doc.merge(VertexApiDoc::openapi());
+    }
+
+    #[cfg(feature = "kserve")]
+    {
+        use crate::kserve::{
+            InferenceOutput, InferenceRequest, LiveResponse, MetadataServerResponse, OutputChunk,
+            ReadyResponse,
+        };
+        use crate::kserve::{
+            __path_kerve_server_metadata, __path_kserve_health_live, __path_kserve_health_ready,
+            __path_kserve_model_infer, __path_kserve_model_metadata,
+            __path_kserve_model_metadata_ready,
+        };
+
+        #[derive(OpenApi)]
+        #[openapi(
+            paths(
+                kserve_model_infer,
+                kserve_health_live,
+                kserve_health_ready,
+                kerve_server_metadata,
+                kserve_model_metadata,
+                kserve_model_metadata_ready,
+            ),
+            components(schemas(
+                InferenceOutput,
+                InferenceRequest,
+                LiveResponse,
+                MetadataServerResponse,
+                OutputChunk,
+                ReadyResponse,
+            ))
+        )]
+        struct KServeApiDoc;
+
+        doc.merge(KServeApiDoc::openapi());
+    }
 
     // Configure Swagger UI
     let swagger_ui = SwaggerUi::new("/docs").url("/api-doc/openapi.json", doc);


### PR DESCRIPTION
This PR adds support for the Open Inference Protocol (V2 Inference Protocol) with the following routes


| Endpoint | Category | Action | Method | Request Payload | Response Payload |
|----------|----------|--------|--------|-----------------|------------------|
| v2/models/[/versions/<model_version>]/infer | Inference |        | POST   | $inference_request | $inference_response |
| v2/models/<model_name>[/versions/<model_version>] | Model    | Metadata | GET    | -                 | $metadata_model_response |
| v2/health/ready | Server   | Ready   | GET    | -                 | $ready_server_response |
| v2/health/live | Server   | Live    | GET    | -                 | $live_server_response |
| v2 | Server   | Metadata | GET    | -                 | $metadata_server_response |
| v2/models/<model_name>[/versions/]/ready | Model    | Ready   | GET    | -                 | - |



docs: https://kserve.github.io/website/0.12/modelserving/data_plane/v2_protocol/#open-inference-protocol-v2-inference-protocol


note: server must be built with `--features kserve`
