### PR TITLE
ROCm and sliding windows fixes

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -476,6 +476,7 @@ fn shard_manager(
     rope_factor: Option<f32>,
     max_total_tokens: usize,
     max_batch_size: Option<usize>,
+    max_batch_prefill_tokens: u32,
     otlp_endpoint: Option<String>,
     log_level: LevelFilter,
     status_sender: mpsc::Sender<ShardStatus>,
@@ -547,6 +548,10 @@ fn shard_manager(
         shard_args.push("--otlp-endpoint".to_string());
         shard_args.push(otlp_endpoint);
     }
+
+    // In case we use sliding window, we may ignore the sliding in flash for some backends depending on the parameter.
+    shard_args.push("--max-batch-prefill-tokens".to_string());
+    shard_args.push(max_batch_prefill_tokens.to_string());
 
     // Copy current process env
     let mut envs: Vec<(OsString, OsString)> = env::vars_os().collect();
@@ -1004,6 +1009,7 @@ fn spawn_shards(
     args: &Args,
     cuda_graphs: Vec<usize>,
     max_total_tokens: usize,
+    max_batch_prefill_tokens: u32,
     max_log_level: LevelFilter,
     shutdown: Arc<AtomicBool>,
     shutdown_receiver: &mpsc::Receiver<()>,
@@ -1061,6 +1067,7 @@ fn spawn_shards(
                 rope_factor,
                 max_total_tokens,
                 max_batch_size,
+                max_batch_prefill_tokens,
                 otlp_endpoint,
                 max_log_level,
                 status_sender,
@@ -1535,6 +1542,7 @@ fn main() -> Result<(), LauncherError> {
         &args,
         cuda_graphs,
         max_total_tokens,
+        max_batch_prefill_tokens,
         max_log_level,
         shutdown.clone(),
         &shutdown_receiver,

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -476,7 +476,7 @@ fn shard_manager(
     rope_factor: Option<f32>,
     max_total_tokens: usize,
     max_batch_size: Option<usize>,
-    max_batch_prefill_tokens: u32,
+    max_input_tokens: usize,
     otlp_endpoint: Option<String>,
     log_level: LevelFilter,
     status_sender: mpsc::Sender<ShardStatus>,
@@ -550,8 +550,8 @@ fn shard_manager(
     }
 
     // In case we use sliding window, we may ignore the sliding in flash for some backends depending on the parameter.
-    shard_args.push("--max-batch-prefill-tokens".to_string());
-    shard_args.push(max_batch_prefill_tokens.to_string());
+    shard_args.push("--max-input-tokens".to_string());
+    shard_args.push(max_input_tokens.to_string());
 
     // Copy current process env
     let mut envs: Vec<(OsString, OsString)> = env::vars_os().collect();
@@ -1009,7 +1009,7 @@ fn spawn_shards(
     args: &Args,
     cuda_graphs: Vec<usize>,
     max_total_tokens: usize,
-    max_batch_prefill_tokens: u32,
+    max_input_tokens: usize,
     max_log_level: LevelFilter,
     shutdown: Arc<AtomicBool>,
     shutdown_receiver: &mpsc::Receiver<()>,
@@ -1067,7 +1067,7 @@ fn spawn_shards(
                 rope_factor,
                 max_total_tokens,
                 max_batch_size,
-                max_batch_prefill_tokens,
+                max_input_tokens,
                 otlp_endpoint,
                 max_log_level,
                 status_sender,
@@ -1542,7 +1542,7 @@ fn main() -> Result<(), LauncherError> {
         &args,
         cuda_graphs,
         max_total_tokens,
-        max_batch_prefill_tokens,
+        max_input_tokens,
         max_log_level,
         shutdown.clone(),
         &shutdown_receiver,

--- a/server/Makefile-vllm
+++ b/server/Makefile-vllm
@@ -1,5 +1,5 @@
 commit_cuda := b5dfc61db88a81069e45b44f7cc99bd9e62a60fa
-commit_rocm := e5d1a20b3a8cb744ce562723f5e1dbe907ee18cc
+commit_rocm := 559200c1a028de990c1ddea761b0ccd62109e3a0
 build-vllm-cuda:
 	if [ ! -d 'vllm' ]; then \
 		pip install -U ninja packaging --no-cache-dir && \

--- a/server/Makefile-vllm
+++ b/server/Makefile-vllm
@@ -1,5 +1,5 @@
 commit_cuda := b5dfc61db88a81069e45b44f7cc99bd9e62a60fa
-commit_rocm := ca6913b3c2ffacdcb7d15e914dc34adbc6c89479
+commit_rocm := e5d1a20b3a8cb744ce562723f5e1dbe907ee18cc
 build-vllm-cuda:
 	if [ ! -d 'vllm' ]; then \
 		pip install -U ninja packaging --no-cache-dir && \
@@ -19,5 +19,5 @@ build-vllm-rocm:
 	PYTORCH_ROCM_ARCH="gfx90a;gfx942" python setup.py build
 
 install-vllm-rocm: build-vllm-rocm
-	cd vllm && git fetch && git checkout $(commit_rocm) &&  \
+	cd vllm && git fetch && git checkout $(commit_rocm) && \
 	PYTORCH_ROCM_ARCH="gfx90a;gfx942" pip install -e .

--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -41,7 +41,7 @@ def serve(
     logger_level: str = "INFO",
     json_output: bool = False,
     otlp_endpoint: Optional[str] = None,
-    max_batch_prefill_tokens: Optional[int] = None,
+    max_input_tokens: Optional[int] = None,
 ):
     if sharded:
         assert (
@@ -98,7 +98,7 @@ def serve(
         dtype,
         trust_remote_code,
         uds_path,
-        max_batch_prefill_tokens,
+        max_input_tokens,
     )
 
 

--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -41,6 +41,7 @@ def serve(
     logger_level: str = "INFO",
     json_output: bool = False,
     otlp_endpoint: Optional[str] = None,
+    max_batch_prefill_tokens: Optional[int] = None,
 ):
     if sharded:
         assert (
@@ -97,6 +98,7 @@ def serve(
         dtype,
         trust_remote_code,
         uds_path,
+        max_batch_prefill_tokens,
     )
 
 

--- a/server/text_generation_server/layers/attention/rocm.py
+++ b/server/text_generation_server/layers/attention/rocm.py
@@ -169,10 +169,8 @@ if ENGINE == "ck":
     ):
         if window_size_left <= 0 and window_size_left != -1:
             raise ValueError("`window_size_left` must be > 0 or -1")
-        if window_size_left != -1 and q.shape[0] > window_size_left:
-            raise ValueError(
-                f"ROCm version of Flash Attention v2 does not support window attention (window_size_left != -1, got window_size_left={window_size_left})."
-            )
+
+        # We do not need to check window_size_left (not supported) here, so it is already checked ahead of time at model load.
         return flash_attn_2_cuda.varlen_fwd(
             q,
             k,
@@ -204,10 +202,7 @@ elif ENGINE == "triton":
         window_size_left=-1,
         causal=True,
     ):
-        if window_size_left != -1 and q.shape[0] > window_size_left:
-            raise ValueError(
-                f"RoCm version of Flash Attention v2 does not support window attention (window_size_left != -1, got window_size_left={window_size_left})."
-            )
+        # We do not need to check window_size_left (not supported) here, so it is already checked ahead of time at model load.
         output, _ = triton_attention(
             q,
             k,

--- a/server/text_generation_server/layers/attention/rocm.py
+++ b/server/text_generation_server/layers/attention/rocm.py
@@ -169,7 +169,7 @@ if ENGINE == "ck":
     ):
         if window_size_left <= 0 and window_size_left != -1:
             raise ValueError("`window_size_left` must be > 0 or -1")
-        if window_size_left != -1:
+        if window_size_left != -1 and q.shape[0] > window_size_left:
             raise ValueError(
                 f"ROCm version of Flash Attention v2 does not support window attention (window_size_left != -1, got window_size_left={window_size_left})."
             )
@@ -204,7 +204,7 @@ elif ENGINE == "triton":
         window_size_left=-1,
         causal=True,
     ):
-        if window_size_left != -1:
+        if window_size_left != -1 and q.shape[0] > window_size_left:
             raise ValueError(
                 f"RoCm version of Flash Attention v2 does not support window attention (window_size_left != -1, got window_size_left={window_size_left})."
             )

--- a/server/text_generation_server/layers/attention/xpu.py
+++ b/server/text_generation_server/layers/attention/xpu.py
@@ -14,10 +14,7 @@ def attention(
     softmax_scale,
     window_size_left=-1,
 ):
-    if window_size_left != -1 and q.shape[0] > window_size_left:
-        raise ValueError(
-            f"XPU version of Flash Attention does not support window attention (window_size_left != -1, got window_size_left={window_size_left})."
-        )
+    # We do not need to check window_size_left (not supported) here, so it is already checked ahead of time at model load.
     return ipex.llm.functional.varlen_attention(
         q,
         k,

--- a/server/text_generation_server/layers/attention/xpu.py
+++ b/server/text_generation_server/layers/attention/xpu.py
@@ -14,7 +14,7 @@ def attention(
     softmax_scale,
     window_size_left=-1,
 ):
-    if window_size_left != -1:
+    if window_size_left != -1 and q.shape[0] > window_size_left:
         raise ValueError(
             f"XPU version of Flash Attention does not support window attention (window_size_left != -1, got window_size_left={window_size_left})."
         )

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -50,8 +50,6 @@ __all__ = [
 
 FLASH_ATT_ERROR_MESSAGE = "{} requires Flash Attention enabled models."
 
-SLIDING_WINDOW_MESSAGE = "The backend {} does not support sliding window attention. TGI webserver was started max_input_tokens={} larger than sliding_window={}. To use this model with the {} backend, please launch TGI with the argument `--max-batch-prefill-tokens` smaller than {}."
-
 FLASH_ATTENTION = True
 
 try:

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -412,9 +412,8 @@ def get_model(
     sliding_window = config_dict.get("sliding_window", -1)
     if sliding_window != -1 and not SUPPORTS_WINDOWING:
         logger.warning(
-            f"Flash attention is available, but doesn't support windowing which is required by model {model_id} for best performance."
+            f"Flash attention is available, but doesn't support windowing which is required by model {model_id} for long contexts."
         )
-        # FLASH_ATTENTION = False
 
     if model_type == MAMBA:
         return Mamba(

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -412,9 +412,9 @@ def get_model(
     sliding_window = config_dict.get("sliding_window", -1)
     if sliding_window != -1 and not SUPPORTS_WINDOWING:
         logger.warning(
-            f"Flash attention is available, but doesn't support windowing which is required by model {model_id}"
+            f"Flash attention is available, but doesn't support windowing which is required by model {model_id} for best performance."
         )
-        FLASH_ATTENTION = False
+        # FLASH_ATTENTION = False
 
     if model_type == MAMBA:
         return Mamba(

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -420,7 +420,7 @@ def get_model(
         and max_input_tokens > sliding_window
     ):
         raise ValueError(
-            f"The backend {SYSTEM} does not support sliding window attention. TGI webserver was started max_input_tokens={max_input_tokens} larger than sliding_window={sliding_window}. To use this model with the {SYSTEM} backend, please launch TGI with the argument `--max-batch-prefill-tokens` smaller than {sliding_window}."
+            f"The backend {SYSTEM} does not support sliding window attention that is used by the model type {model_type}. To use this model nonetheless with the {SYSTEM} backend, please launch TGI with the argument `--max-input-tokens` smaller than sliding_window={sliding_window} (got here max_input_tokens={max_input_tokens})."
         )
 
     if model_type == MAMBA:

--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -899,6 +899,8 @@ class FlashCausalLM(Model):
                 os.environ.get("PYTORCH_TUNABLEOP_ENABLED") is None
                 or os.environ.get("PYTORCH_TUNABLEOP_ENABLED") == "1"
             ):
+                torch.cuda.tunable.enable()
+
                 if os.environ.get("PYTORCH_TUNABLEOP_TUNING") != "0":
                     torch.cuda.tunable.tuning_enable(True)
 

--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -907,8 +907,11 @@ class FlashCausalLM(Model):
                         int(val)
                         for val in os.environ["PYTORCH_TUNABLEOP_SEQLENS"].split(",")
                     ]
-                else:
+                elif CUDA_GRAPHS is not None:
                     tuning_sequences = CUDA_GRAPHS
+                else:
+                    # For seqlen = 1, we dispatch to LLMM1 kernel.
+                    tuning_sequences = [2, 3, 4, 5, 6, 7]
 
                 tunableop_filepath = os.path.join(
                     HUGGINGFACE_HUB_CACHE,

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -199,7 +199,7 @@ def serve(
     dtype: Optional[str],
     trust_remote_code: bool,
     uds_path: Path,
-    max_batch_prefill_tokens: int,
+    max_input_tokens: int,
 ):
     async def serve_inner(
         model_id: str,
@@ -230,7 +230,7 @@ def serve(
                 speculate,
                 dtype,
                 trust_remote_code,
-                max_batch_prefill_tokens,
+                max_input_tokens,
             )
         except Exception:
             logger.exception("Error when initializing model")

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -199,6 +199,7 @@ def serve(
     dtype: Optional[str],
     trust_remote_code: bool,
     uds_path: Path,
+    max_batch_prefill_tokens: int,
 ):
     async def serve_inner(
         model_id: str,
@@ -229,6 +230,7 @@ def serve(
                 speculate,
                 dtype,
                 trust_remote_code,
+                max_batch_prefill_tokens,
             )
         except Exception:
             logger.exception("Error when initializing model")


### PR DESCRIPTION
Fix models requiring window attention - no need to raise an error at load time in case max_input_tokens < sliding_window.

Also, updates vllm fork commit to use the fixes from https://github.com/ROCm/vllm/pull/28 & fix a few rocm issues