### PR TITLE
Update LLMM1 bound

### DIFF
--- a/server/Makefile-vllm
+++ b/server/Makefile-vllm
@@ -1,5 +1,5 @@
 commit_cuda := b5dfc61db88a81069e45b44f7cc99bd9e62a60fa
-commit_rocm := 559200c1a028de990c1ddea761b0ccd62109e3a0
+commit_rocm := c6ee53b1be97e3bbc791b95f22827501297f8921
 build-vllm-cuda:
 	if [ ! -d 'vllm' ]; then \
 		pip install -U ninja packaging --no-cache-dir && \


### PR DESCRIPTION
As per title, see https://github.com/fxmarty/rocm-vllm/commit/c6ee53b1be97e3bbc791b95f22827501297f8921. Were getting some memory access faults because of out of bound loads.