### PR TITLE
fix: set sharded true if WORLD_SIZE is set

### DIFF
--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -44,6 +44,9 @@ def serve(
     otlp_endpoint: Optional[str] = None,
     max_input_tokens: Optional[int] = None,
 ):
+    # derive sharded from environment variables if not provided
+    sharded = sharded or os.getenv("WORLD_SIZE", None) is not None
+
     if sharded:
         assert (
             os.getenv("RANK", None) is not None


### PR DESCRIPTION
This is a tiny PR that simply set assumes `sharded` is true if a `WORLD_SIZE` env is set. 

Adding because I wasted time debugging when I just forgot to set `--sharded` along with the `WORLD_SIZE` and `RANK` env vars. This PR allows `--sharded` to be inferred and is for dev convenience

note** we already do this in the launcher https://github.com/huggingface/text-generation-inference/blob/11ea9ce002e796cc59714950b557b4021cbebc58/launcher/src/main.rs#L518-L521 but this avoids the issue if you are running the server/router separately