### PR TITLE
Fix missing rope scaling option for YaRN

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -148,6 +148,7 @@ impl std::fmt::Display for Dtype {
 enum RopeScaling {
     Linear,
     Dynamic,
+    Yarn,
 }
 
 impl std::fmt::Display for RopeScaling {
@@ -159,6 +160,9 @@ impl std::fmt::Display for RopeScaling {
             }
             RopeScaling::Dynamic => {
                 write!(f, "dynamic")
+            }
+            RopeScaling::Yarn => {
+                write!(f, "yarn")
             }
         }
     }


### PR DESCRIPTION
# What does this PR do?
The issue has been fixed where YaRN was already implemented (#1099) but was missing and unavailable in the launcher under the Rope Scaling option.

Fixes #1320 #1382 #1649

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@OlivierDehaene OR @Narsil

 -->
