### PR TITLE
fix ChatCompletion and ChatCompletionChunk object string not compatible with standard openai api

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -570,7 +570,7 @@ impl ChatCompletion {
         };
         Self {
             id: String::new(),
-            object: "text_completion".into(),
+            object: "chat.completion".into(),
             created,
             model,
             system_fingerprint,
@@ -682,7 +682,7 @@ impl ChatCompletionChunk {
         };
         Self {
             id: String::new(),
-            object: "text_completion".to_string(),
+            object: "chat.completion.chunk".to_string(),
             created,
             model,
             system_fingerprint,


### PR DESCRIPTION
# What does this PR do?
According to OpenAI API doc ([here](https://platform.openai.com/docs/api-reference/chat/object#chat/object-object) and [here](https://platform.openai.com/docs/api-reference/chat/streaming#chat/streaming-object)), the `object` string must be `chat.completion` or `chat.completion.chunk` for `/v1/chat/completion` in non-stream or stream cases. Currently, TGI return `text_completion` for this endpoint, which can cause some error in clients use TGI as openai-compatible-server. e.g, Dify will check `object` string and make sure it must be `chat.completion`.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
