### PR TITLE
corrected Pydantic warning.

### DIFF
--- a/clients/python/text_generation/types.py
+++ b/clients/python/text_generation/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, ConfigDict
 from typing import Optional, List, Union, Any
 
 from text_generation.errors import ValidationError
@@ -452,5 +452,6 @@ class StreamResponse(BaseModel):
 
 # Inference API currently deployed model
 class DeployedModel(BaseModel):
+    model_config  = ConfigDict(protected_namespaces=())
     model_id: str
     sha: str


### PR DESCRIPTION
On using python client with pydantic 2, it raises a warning on import time: 
this corners of the execution logs

Fixes # (1761)

- [ ] I ran it locally with the patch 


@OlivierDehaene 
@Narsil