### PR TITLE
feat: sort cuda graphs in descending order

### DIFF
--- a/server/text_generation_server/models/globals.py
+++ b/server/text_generation_server/models/globals.py
@@ -15,6 +15,13 @@ if cuda_graphs is not None:
 else:
     cuda_graphs = None
 
+
+# sorting the cuda graphs in descending order helps reduce the
+# memory impact and results in less memory usage
+if cuda_graphs is not None:
+    cuda_graphs.sort(reverse=True)
+
+
 CUDA_GRAPHS = cuda_graphs
 
 # This is overridden at model loading.


### PR DESCRIPTION
sorting cuda graphs in descending order uses slightly less memory during initialization 

using the following command on 1 A10G 
```bash
text-generation-launcher \
--model-id meta-llama/Llama-2-7b-chat-hf \
--num-shard 1 \
--cuda-graphs 2,4,8,16,32,64,128,256,512,1024,2048
```

without cuda graphs sorted `22140/23028 MiB` are used and with them sorted `21938/23028 MiB` are used. 

This is a small percent of total memory (`<1%`) however it's 202 MiB saved. Additionally looking at the memory usage overtime, loading in descending order has smaller spike (never goes above its final value, where in ascending it peaks higher than 22222 MiB)


 Below are the two memory recording with [https://github.com/drbh/nvline](https://github.com/drbh/nvline), left is ascending, and right is descending.
 
<img width="2048" alt="desc-graphs-nvline" src="https://github.com/huggingface/text-generation-inference/assets/9896130/8482bc08-3d68-4e58-b2f1-d2e74c1121f4">
