### PR TITLE
feat: use model name as adapter id in chat endpoints

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -370,7 +370,7 @@ pub struct CompletionRequest {
     /// UNUSED
     #[schema(example = "mistralai/Mistral-7B-Instruct-v0.2")]
     /// ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.
-    pub model: String,
+    pub model: Option<String>,
 
     /// The prompt to generate completions for.
     #[schema(example = "What is Deep Learning?")]
@@ -706,7 +706,7 @@ impl ChatCompletionChunk {
 pub(crate) struct ChatRequest {
     #[schema(example = "mistralai/Mistral-7B-Instruct-v0.2")]
     /// [UNUSED] ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.
-    pub model: String,
+    pub model: Option<String>,
 
     /// A list of messages comprising the conversation so far.
     #[schema(example = "[{\"role\": \"user\", \"content\": \"What is Deep Learning?\"}]")]

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -606,6 +606,7 @@ async fn completions(
     metrics::increment_counter!("tgi_request_count");
 
     let CompletionRequest {
+        model,
         max_tokens,
         seed,
         stop,
@@ -673,7 +674,7 @@ async fn completions(
                 seed,
                 top_n_tokens: None,
                 grammar: None,
-                ..Default::default()
+                adapter_id: model.as_ref().filter(|m| *m != "tgi").map(String::from),
             },
         })
         .collect();
@@ -1011,6 +1012,7 @@ async fn chat_completions(
     let span = tracing::Span::current();
     metrics::increment_counter!("tgi_request_count");
     let ChatRequest {
+        model,
         logprobs,
         max_tokens,
         messages,
@@ -1116,7 +1118,7 @@ async fn chat_completions(
             seed,
             top_n_tokens: req.top_logprobs,
             grammar,
-            ..Default::default()
+            adapter_id: model.filter(|m| *m != "tgi").map(String::from),
         },
     };
 


### PR DESCRIPTION
This PR allows users to specify lora adapter ids as the `model` value in the `/v1/chat/completions` and `/v1/completions` endpoints. 

This feature aligns with other lora implementations and was mentioned here during the initial lora PR https://github.com/huggingface/text-generation-inference/pull/2010#issuecomment-2149032186

```bash
curl localhost:3000/v1/chat/completions -s \
    -H 'Content-Type: application/json'  \
    -X POST \
    -d '{
  "model": "predibase/customer_support",
  "messages": [
    {
      "role": "system",
      "content": "You are a helpful assistant."
    },
    {
      "role": "user",
      "content": "What is deep learning?"
    }
  ],
  "stream": false,
  "max_tokens": 20, "seed": 42
}' | jq .
```