### PR TITLE
fix: refactor post_processor logic and add test

### DIFF
--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -320,7 +320,6 @@ async fn main() -> Result<(), RouterError> {
         tokenizer
     });
 
-    // tokenizer.with_post_processor(post_processor);
     let preprocessor_config =
         preprocessor_config_filename.and_then(HubPreprocessorConfig::from_file);
     let processor_config = processor_config_filename


### PR DESCRIPTION
This PR updates the logic for adding a `post_processor` to a tokenizer and should resolve the issues in CI https://github.com/huggingface/text-generation-inference/actions/runs/9698059633/job/26765404563

This PR aims to match the same functionality in `transformers/models/llama/tokenization_llama_fast.py` and fixes an issue where the single and pairs were not correctly constructed and applied. This resulted in a missing `bos_token` and subsequently an issue with accessing slots in `batch.slots[batch.slot_indices]`. Also a test is added for that specific case