### PR TITLE
fix: use weights from base_layer

### DIFF
--- a/server/text_generation_server/models/custom_modeling/flash_llama_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_llama_modeling.py
@@ -309,7 +309,9 @@ class LlamaMLP(nn.Module):
                 dtype=hidden_states.dtype,
                 device="cuda",
             )
-            _custom_C.LLMM_Silu(self.gate_up_proj.linear.weight, hidden_states, out, 8)
+            _custom_C.LLMM_Silu(
+                self.gate_up_proj.base_layer.linear.weight, hidden_states, out, 8
+            )
             return self.down_proj(out, adapter_data)
         else:
             gate_up_states = self.gate_up_proj(hidden_states, adapter_data)


### PR DESCRIPTION
This PR fixes a bug in the `rocm` path for llama. This bug was introduced in the lora adapter pr https://github.com/huggingface/text-generation-inference/pull/2010 and attempts to incorrectly read `.linear.weight` from the `gate_up_proj`.

This throws because `gate_up_proj` is now of type `TensorParallelMultiAdapterLinear` which wraps the type it used to be `TensorParallelColumnLinear`. In order to get the raw weight we need to access it via the `base_layer`