### PR TITLE
Add API_Key for Auth

### DIFF
--- a/docs/source/basic_tutorials/launcher.md
+++ b/docs/source/basic_tutorials/launcher.md
@@ -350,6 +350,12 @@ Options:
           [env: CORS_ALLOW_ORIGIN=]
 
 ```
+## API_KEY
+```shell
+      --api-key <API_KEY>
+          [env: API_KEY=]
+
+```
 ## WATERMARK_GAMMA
 ```shell
       --watermark-gamma <WATERMARK_GAMMA>

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -418,6 +418,10 @@ struct Args {
 
     #[clap(long, env)]
     cors_allow_origin: Vec<String>,
+
+    #[clap(long, env)]
+    api_key: Option<String>,
+
     #[clap(long, env)]
     watermark_gamma: Option<f32>,
     #[clap(long, env)]
@@ -1244,6 +1248,11 @@ fn spawn_webserver(
         router_args.push(origin);
     }
 
+    // OpenTelemetry
+    if let Some(api_key) = args.api_key{
+        router_args.push("--api-key".to_string());
+        router_args.push(api_key);
+    }
     // Ngrok
     if args.ngrok {
         router_args.push("--ngrok".to_string());

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1242,7 +1242,7 @@ fn spawn_webserver(
     router_args.push("--otlp-service-name".to_string());
     router_args.push(otlp_service_name);
 
-    // CORS origins
+    // API Key
     for origin in args.cors_allow_origin.into_iter() {
         router_args.push("--cors-allow-origin".to_string());
         router_args.push(origin);

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -72,6 +72,8 @@ struct Args {
     #[clap(long, env)]
     cors_allow_origin: Option<Vec<String>>,
     #[clap(long, env)]
+    api_key: Option<String>,
+    #[clap(long, env)]
     ngrok: bool,
     #[clap(long, env)]
     ngrok_authtoken: Option<String>,
@@ -113,6 +115,7 @@ async fn main() -> Result<(), RouterError> {
         otlp_endpoint,
         otlp_service_name,
         cors_allow_origin,
+        api_key,
         ngrok,
         ngrok_authtoken,
         ngrok_edge,
@@ -379,6 +382,7 @@ async fn main() -> Result<(), RouterError> {
         validation_workers,
         addr,
         cors_allow_origin,
+        api_key,
         ngrok,
         ngrok_authtoken,
         ngrok_edge,

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1825,7 +1825,7 @@ pub async fn run(
 
         base_routes = base_routes.layer(axum::middleware::from_fn(auth))
     }
-    let health_routes = Router::new()
+    let info_routes = Router::new()
         .route("/", get(health))
         .route("/info", get(get_model_info))
         .route("/health", get(health))
@@ -1846,7 +1846,7 @@ pub async fn run(
     let mut app = Router::new()
         .merge(swagger_ui)
         .merge(base_routes)
-        .merge(health_routes)
+        .merge(info_routes)
         .merge(aws_sagemaker_route);
 
     #[cfg(feature = "google")]

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1815,7 +1815,7 @@ pub async fn run(
                          request: axum::extract::Request,
                          next: axum::middleware::Next| async move {
             match headers.get(AUTHORIZATION) {
-                Some(token) if token == api_key => {
+                Some(token) if token.to_lowercase() == api_key.to_lowercase() => {
                     let response = next.run(request).await;
                     Ok(response)
                 }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1815,7 +1815,7 @@ pub async fn run(
                          request: axum::extract::Request,
                          next: axum::middleware::Next| async move {
             match headers.get(AUTHORIZATION) {
-                Some(token) if token.to_lowercase() == api_key.to_lowercase() => {
+                Some(token) if token.to_str().to_lowercase() == api_key.to_lowercase() => {
                     let response = next.run(request).await;
                     Ok(response)
                 }


### PR DESCRIPTION
Add API_Key for Auth and conditionally add authorisation for non info/health endpoints.

# What does this PR do?
Adding API_KEY similar to TEI. 
1 differentiation being that the middleware layer is not applied to health/info endpoints


Fixes # (issue)
https://github.com/huggingface/text-generation-inference/issues/2026

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@OlivierDehaene OR @Narsil

