### PR TITLE
fix: avoid loading mistral adapters in mixtral

### DIFF
--- a/server/text_generation_server/models/flash_mixtral.py
+++ b/server/text_generation_server/models/flash_mixtral.py
@@ -29,3 +29,10 @@ class FlashMixtral(BaseFlashMistral):
             dtype=dtype,
             trust_remote_code=trust_remote_code,
         )
+
+    @property
+    def supports_adapter_loading(self) -> bool:
+        # Mixtral cannot inherit loading adapters from FlashMistral
+        # since it does not have the same adapter layer mapping
+        # TODO: implement the loading of adapters for Mixtral
+        return False


### PR DESCRIPTION
This PR disables adapters from Mixtral to fix this loading bug 

```
AttributeError: 'MixtralLayer' object has no attribute 'mlp' observed in mistralai/Mixtral-8x7B-Instruct-v0.1
```

This occurs because Mixtral will return `True` supports_adapter_loading from its base class, however Mixtral and Mistral have different weights and require different lora adapter mappings. This PR avoids this issue until the correct mappings are applied in future PR