### PR TITLE
feat: add test to view batch speedup amount

### DIFF
--- a/server/tests/utils/test_qkv_batch_speedup.py
+++ b/server/tests/utils/test_qkv_batch_speedup.py
@@ -1,0 +1,203 @@
+import torch
+from types import SimpleNamespace
+from typing import List, Union, Dict, Optional
+import time
+from pathlib import Path
+from text_generation_server.utils.weights import Weights
+from text_generation_server.models.custom_modeling.flash_llama_modeling import (
+    FlashLlamaAttention,
+)
+
+
+dummy_file_system = {
+    "file1": {
+        "prefix.self_attn.q_proj.weight": torch.rand(
+            4096, 4096
+        ),  # (hidden_size * num_heads, hidden_size)
+        "prefix.self_attn.k_proj.weight": torch.rand(4096, 4096),
+        "prefix.self_attn.v_proj.weight": torch.rand(4096, 4096),
+        "prefix.self_attn.o_proj.weight": torch.rand(
+            4096, 4096
+        ),  # (hidden_size, hidden_size * num_heads)
+        "prefix.self_attn.q_proj.bias": torch.rand(4096),
+        "prefix.self_attn.k_proj.bias": torch.rand(4096),
+        "prefix.self_attn.v_proj.bias": torch.rand(4096),
+        "prefix.self_attn.o_proj.bias": torch.rand(4096),
+    },
+}
+
+
+class MockSlice:
+    def __init__(self, tensor):
+        self.tensor = tensor
+
+    def get_shape(self):
+        return self.tensor.shape
+
+    def __getitem__(self, idx):
+        return self.tensor[idx]
+
+
+def mock_get_slice(tensor_name, filename):
+    tensor = dummy_file_system[filename][tensor_name]
+    return MockSlice(tensor)
+
+
+def mock_handle(filename, device, dtype):
+    return SimpleNamespace(
+        get_slice=lambda tensor_name: mock_get_slice(tensor_name, filename)
+    )
+
+
+class MockSafeOpen:
+    def __init__(self, filename, framework, dummy_fs):
+        self.filename = filename
+        self.framework = framework
+        self.dummy_fs = dummy_fs
+
+    def keys(self):
+        return list(self.dummy_fs[self.filename].keys())
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+class MockWeights(Weights):
+    def __init__(
+        self,
+        filenames: List[Union[Path, str]],
+        device,
+        dtype,
+        process_group,
+        dummy_fs,
+        aliases: Optional[Dict[str, List[str]]] = None,
+        prefix: Optional[str] = None,
+    ):
+        routing = {}
+        self.dummy_fs = dummy_fs
+        for filename in filenames:
+            with MockSafeOpen(filename, framework="pytorch", dummy_fs=dummy_fs) as f:
+                for k in f.keys():
+                    if k in routing:
+                        raise RuntimeError(
+                            f"Key {k} was found in multiple files: {filename} and {routing[k]}"
+                        )
+                    routing[k] = filename
+        if aliases is None:
+            aliases = {}
+        self.aliases = aliases
+        self.routing = routing
+        self.device = device
+        self.dtype = dtype
+        self.process_group = process_group
+        self.prefix = prefix
+        self._handles = {}
+
+    def _get_handle(self, filename: Union[Path, str]):
+        if filename in self._handles:
+            return self._handles[filename]
+        else:
+            handle = mock_handle(filename, self.device, self.dtype)
+            self._handles[filename] = handle
+            return handle
+
+    def get_shape(self, tensor_name: str):
+        filename, _ = self.get_filename(tensor_name)
+        handle = self._get_handle(filename)
+        return handle.get_slice(tensor_name).get_shape()
+
+    def get_tensor(self, tensor_name: str):
+        filename, _ = self.get_filename(tensor_name)
+        handle = self._get_handle(filename)
+        return handle.get_slice(tensor_name).tensor
+
+
+dummy_process_group = SimpleNamespace(rank=lambda: 0, size=lambda: 1)
+
+
+def run_test(attention, input_tensor, num_warmup=0, num_iterations=1):
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+
+    # warm-up
+    for _ in range(num_warmup):
+        attention.query_key_value(input_tensor, None)
+        torch.cuda.synchronize()
+
+    # timed
+    times = []
+    for _ in range(num_iterations):
+        torch.cuda.synchronize()
+        start_time = time.perf_counter()
+        attention.query_key_value(input_tensor, None)
+        torch.cuda.synchronize()
+        end_time = time.perf_counter()
+        times.append((end_time - start_time) * 1000)  # milliseconds
+
+    return sum(times) / len(times)
+
+
+def test_qkv_batch_speedup(capsys):
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    hidden_size = 4096
+    num_heads = 32
+
+    config = SimpleNamespace(
+        num_attention_heads=num_heads,
+        hidden_size=hidden_size,
+        rope_theta=10000.0,
+        num_key_value_heads=num_heads,
+        model_type="llama",
+        quantize=None,
+    )
+
+    weights = MockWeights(
+        filenames=["file1"],
+        device=device,
+        dtype=torch.float32,
+        process_group=dummy_process_group,
+        dummy_fs=dummy_file_system,
+    )
+
+    attention = FlashLlamaAttention(
+        index=0,
+        prefix="prefix.self_attn",
+        config=config,
+        weights=weights,
+    )
+
+    # sequence with various odd lengths
+    sequence_lengths = [3, 35, 365, 3_501, 11_111]
+    batch_sizes = [*range(16)]
+
+    with capsys.disabled():
+        # allow printing
+        for sequence_length in sequence_lengths:
+            print(f"Testing with sequence length: {sequence_length}")
+            print(
+                f"{'Batch Size':<10} {'Batch Time (ms)':<20} {'Sequential Time (ms)':<25} {'Speedup':<10}"
+            )
+            print("-" * 65)
+
+            for batch_size in batch_sizes:
+                # batch
+                batch_input = torch.rand(
+                    sequence_length * batch_size, hidden_size, device=device
+                )
+                batch_time = run_test(attention, batch_input)
+
+                # sequential
+                sequential_time = 0
+                for index in range(batch_size):
+                    single_input = batch_input[
+                        index * sequence_length : (index + 1) * sequence_length
+                    ]
+                    sequential_time += run_test(attention, single_input)
+
+                speedup = sequential_time / batch_time
+                print(
+                    f"{batch_size:<10} {batch_time:<20.2f} {sequential_time:<25.2f} {speedup:<10.2f}"
+                )


### PR DESCRIPTION
This PR adds a very simple test with the goal of giving more insight into speedups from batching vs a single input. 

The test outputs the timing of a single batch op vs iterating over the individual items and helps give insight into rough expected timing for various batch sizes.

```bash
pytest -vvv server/tests/utils/test_qkv_batch_speedup.py
```

ouput
```
============================================ test session starts ============================================
platform linux -- Python 3.11.1, pytest-7.4.0, pluggy-1.5.0 -- /home/ubuntu/Projects/text-generation-inference/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/Projects/text-generation-inference/server
configfile: pyproject.toml
plugins: asyncio-0.23.7, anyio-4.3.0, syrupy-4.0.1
asyncio: mode=Mode.STRICT
collected 1 item

server/tests/utils/test_qkv_batch_speedup.py::test_qkv_batch_speedup Testing with sequence length: 3
Batch Size Batch Time (ms)      Sequential Time (ms)      Speedup
-----------------------------------------------------------------
0          0.17                 0.00                      0.00
1          47.00                0.58                      0.01
2          0.56                 0.99                      1.78
3          0.52                 1.49                      2.85
4          0.52                 1.96                      3.76
5          0.53                 2.47                      4.67
6          0.52                 3.03                      5.77
7          0.66                 3.44                      5.20
8          0.55                 3.98                      7.21
9          0.56                 4.39                      7.90
10         0.56                 4.92                      8.79
11         0.57                 5.55                      9.76
12         0.58                 5.94                      10.25
13         0.61                 6.40                      10.55
14         0.58                 7.05                      12.22
15         0.62                 7.56                      12.20
Testing with sequence length: 35
Batch Size Batch Time (ms)      Sequential Time (ms)      Speedup
-----------------------------------------------------------------
0          0.08                 0.00                      0.00
1          0.57                 0.54                      0.94
2          0.73                 1.08                      1.48
3          0.75                 1.63                      2.19
4          0.93                 2.15                      2.32
5          1.20                 2.80                      2.34
6          1.28                 3.35                      2.62
7          1.28                 3.91                      3.05
8          1.70                 4.42                      2.59
9          1.32                 4.90                      3.72
10         1.66                 5.46                      3.29
11         1.96                 6.05                      3.08
12         1.94                 6.65                      3.44
13         2.15                 7.15                      3.32
14         2.05                 7.68                      3.74
15         2.43                 8.17                      3.36
Testing with sequence length: 365
Batch Size Batch Time (ms)      Sequential Time (ms)      Speedup
-----------------------------------------------------------------
0          0.06                 0.00                      0.00
1          1.64                 1.92                      1.17
2          3.04                 4.30                      1.41
3          4.08                 6.38                      1.56
4          5.53                 8.23                      1.49
5          6.18                 10.16                     1.64
6          7.45                 12.09                     1.62
7          8.04                 13.94                     1.73
8          9.36                 16.24                     1.73
9          10.57                18.27                     1.73
10         11.84                20.00                     1.69
11         13.12                21.91                     1.67
12         13.75                23.77                     1.73
13         15.00                26.04                     1.74
14         15.56                28.10                     1.81
15         17.35                30.00                     1.73
Testing with sequence length: 3501
Batch Size Batch Time (ms)      Sequential Time (ms)      Speedup
-----------------------------------------------------------------
0          0.08                 0.00                      0.00
1          11.17                11.64                     1.04
2          21.86                23.75                     1.09
3          32.52                34.84                     1.07
4          43.39                46.50                     1.07
5          53.92                59.33                     1.10
6          64.55                70.75                     1.10
7          75.40                82.64                     1.10
8          85.56                94.23                     1.10
9          96.05                105.05                    1.09
10         105.86               117.54                    1.11
11         116.41               130.89                    1.12
12         126.60               140.40                    1.11
13         136.51               153.14                    1.12
14         147.00               164.14                    1.12
15         157.39               175.03                    1.11
Testing with sequence length: 11111
Batch Size Batch Time (ms)      Sequential Time (ms)      Speedup
-----------------------------------------------------------------
0          0.07                 0.00                      0.00
1          34.76                34.39                     0.99
2          67.31                70.45                     1.05
3          100.14               106.35                    1.06
4          133.37               142.14                    1.07
5          167.20               176.10                    1.05
6          199.45               211.42                    1.06
7          231.29               246.77                    1.07
8          264.17               281.65                    1.07
9          297.42               315.85                    1.06
10         329.85               354.24                    1.07
11         362.14               388.87                    1.07
12         394.93               422.40                    1.07
13         428.10               457.95                    1.07
14         461.78               496.16                    1.07
15         494.73               531.75                    1.07
PASSED                           [100%]

------------------------------------------ snapshot report summary ------------------------------------------
```