### PR TITLE
misc: update vllm dependency to support attention size 160

### DIFF
--- a/server/Makefile-vllm
+++ b/server/Makefile-vllm
@@ -1,9 +1,9 @@
-commit_cuda := b5dfc61db88a81069e45b44f7cc99bd9e62a60fa
+commit_cuda := e0c577263c2c7f367198d4a51a9964136ea259db
 commit_rocm := c6ee53b1be97e3bbc791b95f22827501297f8921
 build-vllm-cuda:
 	if [ ! -d 'vllm' ]; then \
 		pip install -U ninja packaging --no-cache-dir && \
-		git clone https://github.com/Narsil/vllm.git vllm; \
+		git clone https://github.com/igeniusai/vllm.git vllm; \
 	fi
 	cd vllm  && git fetch && git checkout $(commit_cuda) && python setup.py build
 


### PR DESCRIPTION
# What does this PR do?
changed to a version of vllm that supports head size 160.

or @Narsil if you merge [this](https://github.com/Narsil/vllm/pull/1), I can directly change the commit id 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@OlivierDehaene OR @Narsil

