### PR TITLE
fix: append DONE message to chat stream

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -812,6 +812,10 @@ async fn completions(
             }
         };
 
+        let stream = stream.chain(futures::stream::once(async {
+            Ok(Event::default().data("[DONE]"))
+        }));
+
         let sse = Sse::new(stream).keep_alive(KeepAlive::default());
         Ok((headers, sse).into_response())
     } else {

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1171,6 +1171,11 @@ async fn chat_completions(
             span,
         )
         .await;
+
+        let response_stream = response_stream.chain(futures::stream::once(async {
+            Ok(Event::default().data("[DONE]"))
+        }));
+
         let sse = Sse::new(response_stream).keep_alive(KeepAlive::default());
         Ok((headers, sse).into_response())
     } else {


### PR DESCRIPTION
This PR adds the missing `[DONE]` message to the end of the `/v1/completions` and `/v1/chat/completions` endpoints.

This should resolve: https://github.com/huggingface/text-generation-inference/issues/1896 and align with the openai spec https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream