### PR TITLE
fix custom cache dir 

### DIFF
--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -295,9 +295,6 @@ async fn main() -> Result<(), RouterError> {
             )
         }
     };
-
-
-
     let config: Option<Config> = config_filename.and_then(|filename| {
         std::fs::read_to_string(filename)
             .ok()
@@ -354,7 +351,6 @@ async fn main() -> Result<(), RouterError> {
         tracing::warn!("Could not find a fast tokenizer implementation for {tokenizer_name}");
         tracing::warn!("Rust input length validation and truncation is disabled");
     }
-
 
     // if pipeline-tag == text-generation we default to return_full_text = true
     let compat_return_full_text = match &model_info.pipeline_tag {

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -296,7 +296,6 @@ async fn main() -> Result<(), RouterError> {
         }
     };
 
-    println!("tokenizer_filename: {:?}", tokenizer_filename);
 
 
     let config: Option<Config> = config_filename.and_then(|filename| {
@@ -356,7 +355,6 @@ async fn main() -> Result<(), RouterError> {
         tracing::warn!("Rust input length validation and truncation is disabled");
     }
 
-    println!("Using config {config:?}");
 
     // if pipeline-tag == text-generation we default to return_full_text = true
     let compat_return_full_text = match &model_info.pipeline_tag {

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -214,7 +214,7 @@ async fn main() -> Result<(), RouterError> {
                 .map_err(|_| ())
                 .map(|cache_dir| Cache::new(cache_dir.into()))
                 .unwrap_or_else(|_| Cache::default());
-            
+
             tracing::warn!("Offline mode active using cache defaults");
             Type::Cache(cache)
         } else {


### PR DESCRIPTION
# What does this PR do?
- Fixes #2147

### How to reproduce the bug
- env vars `HUGGINGFACE_HUB_CACHE=/some/other/dir` and `HF_HUB_OFFLINE=1` have to be set
- launch with e.g. this tokenizer `text-generation-router --tokenizer-name meta-llama/Meta-Llama-3-8B-Instruct`
- result, the `tokenizer_file_name` is `None` and the config as well 

```
2024-07-12T12:40:29.724257Z  WARN text_generation_router: router/src/main.rs:328: Could not find tokenizer config locally and no API specified
2024-07-12T12:40:29.724292Z  INFO text_generation_router: router/src/main.rs:353: Using config None
2024-07-12T12:40:29.724307Z  WARN text_generation_router: router/src/main.rs:355: Could not find a fast tokenizer implementation for meta-llama/Meta-Llama-3-8B-Instruct
```

### Fix
- check if HUGGINGFACE_HUB_CACHE is set and use that
- if not --> then use the `Cache::default()`

This was most likely to only come up when running TGI in docker since there the `ENV HUGGINGFACE_HUB_CACHE=/data \` is set to something besides the default.