### PR TITLE
OpenAI compatibility fix: valid `top_p` value range is 0.0 to 1.0.

### DIFF
--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -247,7 +247,7 @@ impl Validation {
         // for the user
         let top_p = top_p
             .map(|value| {
-                if value <= 0.0 || value >= 1.0 {
+                if value < 0.0 || value > 1.0 {
                     return Err(ValidationError::TopP);
                 }
                 Ok(value)


### PR DESCRIPTION
#### OpenAI compatibility fix: valid `top_p` value range is 0.0 to 1.0.

> Don't error out on OpenAI `top_p` valid values.

* Closes: https://github.com/huggingface/text-generation-inference/issues/2222
* Closes: https://github.com/guidance-ai/guidance/issues/945

#### What does this PR do?

Improves compatibility with OpenAI clients that expect `top_p` to be valid from `0.0` to `1.0` inclusive.

#### Fixes:

* https://github.com/huggingface/text-generation-inference/issues/2222
* https://github.com/guidance-ai/guidance/issues/945
