### PR TITLE
fix: adjust default tool choice

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -909,7 +909,7 @@
           "tool_choice": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ToolType"
+                "$ref": "#/components/schemas/ToolChoice"
               }
             ],
             "nullable": true
@@ -2035,6 +2035,14 @@
           }
         }
       },
+      "ToolChoice": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolType"
+          }
+        ],
+        "nullable": true
+      },
       "ToolType": {
         "oneOf": [
           {
@@ -2055,6 +2063,11 @@
                 "$ref": "#/components/schemas/FunctionName"
               }
             }
+          },
+          {
+            "type": "object",
+            "default": null,
+            "nullable": true
           }
         ]
       },

--- a/router/src/infer/mod.rs
+++ b/router/src/infer/mod.rs
@@ -336,8 +336,14 @@ impl ToolGrammar {
         tools: Option<Vec<Tool>>,
         tool_choice: Option<ToolType>,
     ) -> Result<Option<Tools>, InferError> {
-        if let Some((req_tools, tool_choice)) = tools.zip(tool_choice) {
-            // let tool_prompt = tool_prompt.unwrap_or_default();
+        if let Some(req_tools) = tools {
+            let tool_choice = tool_choice
+                .map(|t| match t {
+                    ToolType::FunctionName(name) if name == "auto" => ToolType::OneOf,
+                    _ => t,
+                })
+                .unwrap_or_default();
+
             let tools_to_use = match tool_choice {
                 ToolType::FunctionName(name) => {
                     vec![req_tools

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -854,7 +854,7 @@ pub struct FunctionName {
     pub name: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, ToSchema)]
 #[serde(from = "ToolTypeDeserializer")]
 pub struct ToolChoice(pub Option<ToolType>);
 

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1371,47 +1371,4 @@ mod tests {
             r#"{"role":"assistant","tool_calls":[{"id":"0","type":"function","function":{"description":null,"name":"myfn","arguments":{"format":"csv"}}}]}"#
         );
     }
-    #[test]
-    fn tool_deserialize() {
-        // Test ToolCall deserialization
-        let json = r#"{"id":"0","type":"function","function":{"description":null,"name":"myfn","arguments":{"format":"csv"}}}"#;
-        let tool: ToolCall = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            tool,
-            ToolCall {
-                id: "0".to_string(),
-                r#type: "function".to_string(),
-                function: FunctionDefinition {
-                    description: None,
-                    name: "myfn".to_string(),
-                    arguments: json!({
-                        "format": "csv"
-                    }),
-                },
-            }
-        );
-
-        // Test ToolChoice deserialization with "auto"
-        let auto_json = r#""auto""#;
-        let auto_choice: ToolChoice = serde_json::from_str(auto_json).unwrap();
-        assert_eq!(auto_choice, ToolChoice(Some(ToolType::OneOf)));
-
-        // Test ToolChoice deserialization with "none"
-        let none_json = r#""none""#;
-        let none_choice: ToolChoice = serde_json::from_str(none_json).unwrap();
-        assert_eq!(none_choice, ToolChoice(None));
-
-        // Test ToolChoice deserialization with a specific function name
-        let function_json = r#""my_function""#;
-        let function_choice: ToolChoice = serde_json::from_str(function_json).unwrap();
-        assert_eq!(
-            function_choice,
-            ToolChoice(Some(ToolType::FunctionName("my_function".to_string())))
-        );
-
-        // Test ToolChoice deserialization with no value (should default to OneOf)
-        let default_json = r#"null"#;
-        let default_choice: ToolChoice = serde_json::from_str(default_json).unwrap();
-        assert_eq!(default_choice, ToolChoice(Some(ToolType::OneOf)));
-    }
 }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -840,12 +840,16 @@ fn default_tool_prompt() -> Option<String> {
     )
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 #[serde(untagged)]
 pub enum ToolType {
+    #[default]
+    #[serde(alias = "auto")]
     OneOf,
     FunctionName(String),
-    Function { function: FunctionName },
+    Function {
+        function: FunctionName,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -24,7 +24,7 @@ use crate::{
     CompletionRequest, CompletionType, DeltaToolCall, Function, Prompt, Tool, VertexRequest,
     VertexResponse,
 };
-use crate::{FunctionDefinition, HubPreprocessorConfig, ToolCall, ToolType};
+use crate::{FunctionDefinition, HubPreprocessorConfig, ToolCall, ToolChoice, ToolType};
 use async_stream::__private::AsyncStream;
 use axum::extract::Extension;
 use axum::http::{HeaderMap, Method, StatusCode};
@@ -1492,6 +1492,7 @@ pub async fn run(
     ToolCall,
     Function,
     FunctionDefinition,
+    ToolChoice,
     )
     ),
     tags(

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1192,39 +1192,33 @@ async fn chat_completions(
             .as_secs();
 
         let (tool_calls, output) = if tool_grammar.is_some() {
-            // gen_text should be valid json
-            let gen_text_value: Value =
-                serde_json::from_str(&generation.generated_text).map_err(|e| {
-                    (
-                        StatusCode::UNPROCESSABLE_ENTITY,
-                        Json(ErrorResponse {
-                            error: e.to_string(),
-                            error_type: "Input validation error".to_string(),
-                        }),
-                    )
-                })?;
+            let gen_text_value: Value = serde_json::from_str(&generation.generated_text)
+                .map_err(|e| InferError::ToolError(e.to_string()))?;
+
+            let function = gen_text_value.get("function").ok_or(InferError::ToolError(
+                "No function found in generated text".to_string(),
+            ))?;
+
+            let name = function
+                .get("_name")
+                .and_then(Value::as_str)
+                .ok_or(InferError::ToolError(
+                    "No _name found in generated text".to_string(),
+                ))?
+                .to_string();
+
+            let mut arguments = function.clone();
+            if let Value::Object(ref mut props) = arguments {
+                props.remove("_name");
+            }
+
             let tool_calls = vec![ToolCall {
                 id: "0".to_string(),
                 r#type: "function".to_string(),
                 function: FunctionDefinition {
                     description: None,
-                    name: gen_text_value
-                        .get("function")
-                        .and_then(|f| f.get("_name"))
-                        .and_then(|name| name.as_str())
-                        .unwrap_or("default_function_name")
-                        .to_string(),
-                    // Serialize the JSON object obtained from "function" to an escaped JSON string
-                    arguments: gen_text_value
-                        .get("function")
-                        .map(|f| {
-                            let mut f_cloned = f.clone();
-                            if let Value::Object(ref mut props) = f_cloned {
-                                props.remove("_name");
-                            }
-                            f_cloned
-                        })
-                        .unwrap_or_default(),
+                    name,
+                    arguments,
                 },
             }];
             (Some(tool_calls), None)


### PR DESCRIPTION
This PR fixes a regression with the default and auto tool_choice. These changes will ensure that `auto` tools work, and to use `OneOf` in the case tools are provided without a tool_choice