### PR TITLE
add usage stats to toctree

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -21,6 +21,8 @@
     title: Messages API
   - local: architecture
     title: Internal Architecture
+  - local: usage_statistics
+    title: Usage Statistics
   title: Getting started
 - sections:
   - local: basic_tutorials/consuming_tgi


### PR DESCRIPTION
# What does this PR do?
- adds the `usage_statistics` to the `_toctree.yml`