### PR TITLE
patch-error-on-invalid-grammar

### DIFF
--- a/server/text_generation_server/utils/logits_process.py
+++ b/server/text_generation_server/utils/logits_process.py
@@ -524,8 +524,9 @@ class GrammarLogitProcessor(LogitsProcessor):
             try:
                 schema = build_regex_from_schema(schema)
             except Exception as e:
-                logger.error(f"Error compiling FSM: {e}")
-                return None
+                logger.error(f"Error compiling FSM, grammar won't be enforced \n{e}")
+                # allows everything
+                schema = "(.*?)"
         elif grammar_type == GrammarType.GRAMMAR_TYPE_REGEX:
             pass  # schema is already a regex just here for clarity
         fsm = RegexFSM(schema, tokenizer)

--- a/server/text_generation_server/utils/logits_process.py
+++ b/server/text_generation_server/utils/logits_process.py
@@ -521,7 +521,11 @@ class GrammarLogitProcessor(LogitsProcessor):
     def _cached_compile_fsm(grammar_type, schema, tokenizer):
         start_time = time.time()
         if grammar_type == GrammarType.GRAMMAR_TYPE_JSON:
-            schema = build_regex_from_schema(schema)
+            try:
+                schema = build_regex_from_schema(schema)
+            except Exception as e:
+                logger.error(f"Error compiling FSM: {e}")
+                return None
         elif grammar_type == GrammarType.GRAMMAR_TYPE_REGEX:
             pass  # schema is already a regex just here for clarity
         fsm = RegexFSM(schema, tokenizer)

--- a/server/text_generation_server/utils/logits_process.py
+++ b/server/text_generation_server/utils/logits_process.py
@@ -523,6 +523,7 @@ class GrammarLogitProcessor(LogitsProcessor):
         if grammar_type == GrammarType.GRAMMAR_TYPE_JSON:
             try:
                 schema = build_regex_from_schema(schema)
+            # TODO: this is only here short term to avoid crashing the python server, mid term we want this in the rust/router layer
             except Exception as e:
                 logger.error(f"Error compiling FSM, grammar won't be enforced \n{e}")
                 # allows everything


### PR DESCRIPTION
# What does this PR do?
- fixes #2280

# Implementation
Try + except the `schema = build_regex_from_schema(schema)` and return `None` from `_cached_compile_fsm` if grammar compilation fails.

There might be a better place to do the error handling. This solution in a way creates two errors, like here:

```bash
2024-07-23T09:06:27.017813Z  INFO text_generation_router::server: router/src/server.rs:1651: Setting max batch total tokens to 16000
2024-07-23T09:06:27.285053Z  INFO text_generation_router::server: router/src/server.rs:1889: Connected
2024-07-23T09:06:35.377377Z ERROR text_generation_launcher: Error compiling FSM: Could not translate the instance {'abc': 'def'} to a
    regular expression. Make sure it is valid to the JSON Schema specification. If
    it is, please open an issue on the Outlines repository
2024-07-23T09:06:35.489362Z ERROR text_generation_launcher: Method Prefill encountered an error.
Traceback (most recent call last):
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/bin/text-generation-server", line 8, in <module>
    sys.exit(app())
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/typer/main.py", line 311, in __call__
    return get_command(self)(*args, **kwargs)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/typer/core.py", line 778, in main
    return _main(
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/typer/core.py", line 216, in _main
    rv = self.invoke(ctx)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/typer/main.py", line 683, in wrapper
    return callback(**use_params)  # type: ignore
  File "/Users/erikkaum/Documents/text-generation-inference/server/text_generation_server/cli.py", line 118, in serve
    server.serve(
  File "/Users/erikkaum/Documents/text-generation-inference/server/text_generation_server/server.py", line 297, in serve
    asyncio.run(
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/asyncio/base_events.py", line 641, in run_until_complete
    self.run_forever()
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/asyncio/base_events.py", line 608, in run_forever
    self._run_once()
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/asyncio/base_events.py", line 1936, in _run_once
    handle._run()
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/asyncio/events.py", line 84, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/grpc_interceptor/server.py", line 165, in invoke_intercept_method
    return await self.intercept(
> File "/Users/erikkaum/Documents/text-generation-inference/server/text_generation_server/interceptor.py", line 21, in intercept
    return await response
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/opentelemetry/instrumentation/grpc/_aio_server.py", line 120, in _unary_interceptor
    raise error
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/site-packages/opentelemetry/instrumentation/grpc/_aio_server.py", line 111, in _unary_interceptor
    return await behavior(request_or_iterator, context)
  File "/Users/erikkaum/Documents/text-generation-inference/server/text_generation_server/server.py", line 149, in Prefill
    generations, next_batch, timings = self.model.generate_token(batch)
  File "/Users/erikkaum/miniconda3/envs/text-generation-inference/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
  File "/Users/erikkaum/Documents/text-generation-inference/server/text_generation_server/models/causal_lm.py", line 857, in generate_token
    batch.next_token_choosers[i] = batch.next_token_choosers[i].advance_grammar(
  File "/Users/erikkaum/Documents/text-generation-inference/server/text_generation_server/utils/tokens.py", line 103, in advance_grammar
    self.fsm_grammar_state = self.grammar_processor.advance(
  File "/Users/erikkaum/Documents/text-generation-inference/server/text_generation_server/utils/logits_process.py", line 508, in advance
    return GrammarLogitProcessor._advance(
  File "/Users/erikkaum/Documents/text-generation-inference/server/text_generation_server/utils/logits_process.py", line 516, in _advance
    return fsm.next_state(fsm_grammar_state, next_token_id)
AttributeError: 'NoneType' object has no attribute 'next_state'
2024-07-23T09:06:35.489499Z ERROR batch{batch_size=1}:prefill:prefill{id=0 size=1}:prefill{id=0 size=1}: text_generation_client: router/client/src/lib.rs:46: Server error: 'NoneType' object has no attribute 'next_state'
2024-07-23T09:06:35.489926Z ERROR generate{parameters=GenerateParameters { best_of: None, temperature: None, repetition_penalty: None, frequency_penalty: None, top_k: None, top_p: None, typical_p: None, do_sample: false, max_new_tokens: Some(100), return_full_text: None, stop: [], truncate: None, watermark: false, details: false, decoder_input_details: false, seed: None, top_n_tokens: None, grammar: Some(Json(Object {"abc": String("def")})), adapter_id: None }}:generate:generate_stream:schedule:infer:send_error: text_generation_router::infer::v3::scheduler: router/src/infer/v3/scheduler.rs:493: Request failed during generation: Server error: 'NoneType' object has no attribute 'next_state'
```

But the error from outlines is clear and this doesn't crash the server. So the job gets done.

This is what the result looks like on the client side:
```bash
{"error":"Request failed during generation: Server error: 'NoneType' object has no attribute 'next_state'","error_type":"generation"}
```