### PR TITLE
Fix missing model id in rocm warmup

### DIFF
--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -44,7 +44,7 @@ from text_generation_server.models.globals import (
     BLOCK_SIZE,
     CUDA_GRAPHS,
     get_adapter_to_index,
-    MODEL_ID,
+    get_model_id,
 )
 from text_generation_server.layers.attention import Seqlen
 from text_generation_server.utils import StoppingCriteria, HeterogeneousNextTokenChooser
@@ -1155,9 +1155,10 @@ class FlashCausalLM(Model):
                     # For seqlen = 1, we dispatch to LLMM1 kernel.
                     tuning_sequences = [2, 3, 4, 5, 6, 7]
 
+                model_id = get_model_id()
                 tunableop_filepath = os.path.join(
                     HUGGINGFACE_HUB_CACHE,
-                    f"tunableop_{MODEL_ID.replace('/', '-')}_tp{self.world_size}_rank{self.rank}.csv",
+                    f"tunableop_{model_id.replace('/', '-')}_tp{self.world_size}_rank{self.rank}.csv",
                 )
 
                 log_master(

--- a/server/text_generation_server/models/globals.py
+++ b/server/text_generation_server/models/globals.py
@@ -37,6 +37,10 @@ def set_model_id(model_id: str):
     global MODEL_ID
     MODEL_ID = model_id
 
+def get_model_id():
+    global MODEL_ID
+    return MODEL_ID
+
 
 # NOTE: eventually we should move this into the router and pass back the
 # index in all cases.


### PR DESCRIPTION
# Fix None MODEL_ID Issue During ROCm Warmup Step

This merge request addresses an issue where the global variable MODEL_ID is not consistently updated across different modules. The problem arises because importing MODEL_ID directly from `text_generation_server.models.globals`  results in a copy of the variable's value at the time of import, which does not reflect subsequent changes. To solve this, the code has been refactored to use a getter function (get_model_id()) to access the current value of MODEL_ID instead of importing the variable directly.

Fixes #2297


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@OlivierDehaene OR @Narsil
