### PR TITLE
fix: reject grammars without properties

### DIFF
--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -353,6 +353,14 @@ impl Validation {
                             .compile(&json)
                             .map_err(|e| ValidationError::InvalidGrammar(e.to_string()))?;
 
+                        // The schema can be valid but lack properties.
+                        // We need properties for the grammar to be successfully parsed in Python.
+                        // Therefore, we must check and throw an error if properties are missing.
+                        json.get("properties")
+                            .ok_or(ValidationError::InvalidGrammar(
+                                "Grammar must have a 'properties' field".to_string(),
+                            ))?;
+
                         // Serialize json to string
                         ValidGrammar::Json(
                             serde_json::to_string(&json)


### PR DESCRIPTION
This PR is adds a new check to grammar validation that ensures that the grammar contains `properties` 

For a grammar to be valid it needs to 1. be a valid `JSON Schema`, and 2. have `properties` that are used to constrain the output.


This PR is related to 
pr: https://github.com/huggingface/text-generation-inference/pull/2282 
issue: https://github.com/huggingface/text-generation-inference/issues/2280


### req/res example

The following request would crash TGI due to outlines failing to parse the grammar, now an error is returned because `value` does not include `properties`

```bash
curl localhost:3000/generate \
    -X POST \
    -H 'Content-Type: application/json' \
    -d '{
        "inputs": "My name is Olivier and I",
        "parameters": {
            "grammar": {"type": "json", "value": {"abc":"def"}}
            }
        }'
```

now returns 

```json
{
    "error": "Input validation error: grammar is not valid: Grammar must have a 'properties' field",
    "error_type": "validation"
}
```