### PR TITLE
feat: implement a templated endpoint for visibility into chat requests

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1158,6 +1158,12 @@ pub(crate) struct GenerateResponse {
 }
 
 #[derive(Serialize, ToSchema)]
+pub(crate) struct ChatTokenizeResponse {
+    pub(crate) tokenize_response: TokenizeResponse,
+    pub(crate) templated_text: String,
+}
+
+#[derive(Serialize, ToSchema)]
 #[serde(transparent)]
 pub(crate) struct TokenizeResponse(Vec<SimpleToken>);
 

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -121,7 +121,7 @@ async fn get_model_info(info: Extension<Info>) -> Json<Info> {
     tag = "Text Generation Inference",
     path = "/chat_tokenize",
     request_body = ChatRequest,
-    responses((status = 200, description = "Templated Chat Request", body = Value))
+    responses((status = 200, description = "Templated and tokenized ChatRequest", body = ChatTokenizeResponse))
 )]
 async fn get_chat_tokenize(
     Extension(infer): Extension<Infer>,


### PR DESCRIPTION
This PR adds a new `/templated` POST endpoint to allow users to send a `ChatRequest` and return the templated request. This can help with prompt engineering and for debugging/transparency purposes.


```bash
curl localhost:3000/chat_tokenize -s \
    -H 'Content-Type: application/json'  \
    -X POST \
    -d '{
  "model": "meta-llama/Meta-Llama-3.1-405B-Instruct",
  "messages": [
    {
      "role": "system",
      "content": "You are a helpful assistant."
    },
    {
      "role": "user",
      "content": "What is deep learning?"
    }
  ],
  "stream": false,
  "max_tokens": 20, "seed": 42, "tools": null
}' | jq
```

```json
{
  "tokenize_response": [
    {
      "id": 128000,
      "text": "",
      "start": 0,
      "stop": 0
    },
    {
      "id": 128000,
      "text": "<|begin_of_text|>",
      "start": 0,
      "stop": 17
    },
    {
      "id": 128006,
      "text": "<|start_header_id|>",
      "start": 17,
      "stop": 36
    },
    {
      "id": 9125,
      "text": "",
      "start": 36,
      "stop": 36
    },
    {
      "id": 128007,
      "text": "<|end_header_id|>",
      "start": 42,
      "stop": 59
    },
    {
      "id": 271,
      "text": "",
      "start": 59,
      "stop": 59
    },
    {
      "id": 38766,
      "text": "Cut",
      "start": 61,
      "stop": 64
    },
    {
      "id": 1303,
      "text": "ting",
      "start": 64,
      "stop": 68
    },
    {
      "id": 33025,
      "text": "",
      "start": 68,
      "stop": 68
    },
    {
      "id": 2696,
      "text": "",
      "start": 78,
      "stop": 78
    },
    {
      "id": 25,
      "text": "",
      "start": 83,
      "stop": 83
    },
    {
      "id": 6790,
      "text": "",
      "start": 84,
      "stop": 84
    },
    {
      "id": 220,
      "text": "",
      "start": 93,
      "stop": 93
    },
    {
      "id": 2366,
      "text": "",
      "start": 94,
      "stop": 94
    },
    {
      "id": 18,
      "text": "",
      "start": 97,
      "stop": 97
    },
    {
      "id": 198,
      "text": "",
      "start": 98,
      "stop": 98
    },
    {
      "id": 15724,
      "text": "",
      "start": 99,
      "stop": 99
    },
    {
      "id": 2696,
      "text": "",
      "start": 104,
      "stop": 104
    },
    {
      "id": 25,
      "text": "",
      "start": 109,
      "stop": 109
    },
    {
      "id": 220,
      "text": "",
      "start": 110,
      "stop": 110
    },
    {
      "id": 1627,
      "text": "",
      "start": 111,
      "stop": 111
    },
    {
      "id": 10263,
      "text": "",
      "start": 113,
      "stop": 113
    },
    {
      "id": 220,
      "text": "",
      "start": 117,
      "stop": 117
    },
    {
      "id": 2366,
      "text": "",
      "start": 118,
      "stop": 118
    },
    {
      "id": 19,
      "text": "",
      "start": 121,
      "stop": 121
    },
    {
      "id": 271,
      "text": "",
      "start": 122,
      "stop": 122
    },
    {
      "id": 2675,
      "text": "",
      "start": 124,
      "stop": 124
    },
    {
      "id": 527,
      "text": "",
      "start": 127,
      "stop": 127
    },
    {
      "id": 264,
      "text": "",
      "start": 131,
      "stop": 131
    },
    {
      "id": 11190,
      "text": "",
      "start": 133,
      "stop": 133
    },
    {
      "id": 18328,
      "text": "",
      "start": 141,
      "stop": 141
    },
    {
      "id": 13,
      "text": "",
      "start": 151,
      "stop": 151
    },
    {
      "id": 128009,
      "text": "<|eot_id|>",
      "start": 152,
      "stop": 162
    },
    {
      "id": 128006,
      "text": "<|start_header_id|>",
      "start": 162,
      "stop": 181
    },
    {
      "id": 882,
      "text": "",
      "start": 181,
      "stop": 181
    },
    {
      "id": 128007,
      "text": "<|end_header_id|>",
      "start": 185,
      "stop": 202
    },
    {
      "id": 271,
      "text": "",
      "start": 202,
      "stop": 202
    },
    {
      "id": 3923,
      "text": "",
      "start": 204,
      "stop": 204
    },
    {
      "id": 374,
      "text": "",
      "start": 208,
      "stop": 208
    },
    {
      "id": 5655,
      "text": "",
      "start": 211,
      "stop": 211
    },
    {
      "id": 6975,
      "text": "",
      "start": 216,
      "stop": 216
    },
    {
      "id": 30,
      "text": "",
      "start": 225,
      "stop": 225
    },
    {
      "id": 128009,
      "text": "<|eot_id|>",
      "start": 226,
      "stop": 236
    },
    {
      "id": 128006,
      "text": "<|start_header_id|>",
      "start": 236,
      "stop": 255
    },
    {
      "id": 78191,
      "text": "",
      "start": 255,
      "stop": 255
    },
    {
      "id": 128007,
      "text": "<|end_header_id|>",
      "start": 264,
      "stop": 281
    },
    {
      "id": 271,
      "text": "",
      "start": 281,
      "stop": 281
    }
  ],
  "templated_text": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nCutting Knowledge Date: December 2023\nToday Date: 26 Jul 2024\n\nYou are a helpful assistant.<|eot_id|><|start_header_id|>user<|end_header_id|>\n\nWhat is deep learning?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
}
```