### PR TITLE
fix: improve completions to send a final chunk with usage details

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1824,13 +1824,20 @@
         "type": "object",
         "required": [
           "finish_reason",
-          "generated_tokens"
+          "generated_tokens",
+          "input_length"
         ],
         "properties": {
           "finish_reason": {
             "$ref": "#/components/schemas/FinishReason"
           },
           "generated_tokens": {
+            "type": "integer",
+            "format": "int32",
+            "example": 1,
+            "minimum": 0
+          },
+          "input_length": {
             "type": "integer",
             "format": "int32",
             "example": 1,

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1211,7 +1211,7 @@ pub(crate) struct ChatTokenizeResponse {
 #[serde(transparent)]
 pub(crate) struct TokenizeResponse(Vec<SimpleToken>);
 
-#[derive(Serialize, ToSchema, Debug)]
+#[derive(Serialize, ToSchema)]
 pub(crate) struct StreamDetails {
     #[schema(example = "length")]
     pub finish_reason: FinishReason,
@@ -1223,7 +1223,7 @@ pub(crate) struct StreamDetails {
     pub input_length: u32,
 }
 
-#[derive(Serialize, ToSchema, Debug)]
+#[derive(Serialize, ToSchema)]
 pub(crate) struct StreamResponse {
     pub index: u32,
     pub token: Token,

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1211,7 +1211,7 @@ pub(crate) struct ChatTokenizeResponse {
 #[serde(transparent)]
 pub(crate) struct TokenizeResponse(Vec<SimpleToken>);
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, ToSchema, Debug)]
 pub(crate) struct StreamDetails {
     #[schema(example = "length")]
     pub finish_reason: FinishReason,
@@ -1219,9 +1219,11 @@ pub(crate) struct StreamDetails {
     pub generated_tokens: u32,
     #[schema(nullable = true, example = 42)]
     pub seed: Option<u64>,
+    #[schema(example = 1)]
+    pub input_length: u32,
 }
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, ToSchema, Debug)]
 pub(crate) struct StreamResponse {
     pub index: u32,
     pub token: Token,

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -814,7 +814,7 @@ async fn completions(
                                 model: model_id.clone(),
                                 system_fingerprint: system_fingerprint.clone(),
                                 choices: vec![CompletionComplete {
-                                    finish_reason: String::new(),
+                                    finish_reason: details.finish_reason.to_string(),
                                     index: index as u32,
                                     logprobs: None,
                                     text: stream_token.token.text,

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -533,7 +533,7 @@ async fn generate_stream_internal(
         } else {
             match infer.generate_stream(req).instrument(info_span!(parent: &span, "async_stream")).await {
                 // Keep permit as long as generate_stream lives
-                Ok((_permit, input_length, mut response_stream)) => {
+                Ok((_permit, input_length, response_stream)) => {
                     let mut index = 0;
                     let mut response_stream = Box::pin(response_stream);
                     // Server-Sent Event stream

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -533,7 +533,7 @@ async fn generate_stream_internal(
         } else {
             match infer.generate_stream(req).instrument(info_span!(parent: &span, "async_stream")).await {
                 // Keep permit as long as generate_stream lives
-                Ok((_permit, _input_length, response_stream)) => {
+                Ok((_permit, input_length, mut response_stream)) => {
                     let mut index = 0;
                     let mut response_stream = Box::pin(response_stream);
                     // Server-Sent Event stream
@@ -576,6 +576,7 @@ async fn generate_stream_internal(
                                                 finish_reason: generated_text.finish_reason,
                                                 generated_tokens: generated_text.generated_tokens,
                                                 seed: generated_text.seed,
+                                                input_length,
                                             }),
                                             false => None,
                                         };
@@ -801,21 +802,46 @@ async fn completions(
                         .unwrap_or_else(|_| std::time::Duration::from_secs(0))
                         .as_secs();
 
-                    event
-                        .json_data(Completion::Chunk(Chunk {
-                            id: "".to_string(),
-                            created: current_time,
+                    let message = match stream_token.details {
+                        Some(details) => {
+                            let completion_tokens = details.generated_tokens;
+                            let prompt_tokens = details.input_length;
+                            let total_tokens = prompt_tokens + completion_tokens;
 
+                            Completion::Final(CompletionFinal {
+                                id: String::new(),
+                                created: current_time,
+                                model: model_id.clone(),
+                                system_fingerprint: system_fingerprint.clone(),
+                                choices: vec![CompletionComplete {
+                                    finish_reason: String::new(),
+                                    index: index as u32,
+                                    logprobs: None,
+                                    text: stream_token.token.text,
+                                }],
+                                usage: Usage {
+                                    prompt_tokens,
+                                    completion_tokens,
+                                    total_tokens,
+                                },
+                            })
+                        }
+                        None => Completion::Chunk(Chunk {
+                            id: String::new(),
+                            created: current_time,
                             choices: vec![CompletionComplete {
-                                finish_reason: "".to_string(),
+                                finish_reason: String::new(),
                                 index: index as u32,
                                 logprobs: None,
                                 text: stream_token.token.text,
                             }],
-
                             model: model_id.clone(),
                             system_fingerprint: system_fingerprint.clone(),
-                        }))
+                        }),
+                    };
+
+                    event
+                        .json_data(message)
                         .unwrap_or_else(|_e| Event::default())
                 };
 


### PR DESCRIPTION
This PR fixes an issue with the `/v1/completions` endpoint where the final messages was not treated as a `CompletionFinal`. This resulted in all of the streaming responses retuning empty usage information and no finish_reason. Now if the chunk is final we handle it accordingly.

Repro

```python
from openai import OpenAI
import os

client = OpenAI(
    base_url="http://localhost:3000/v1",
    api_key=os.getenv("HF_TOKEN", "YOUR_API_KEY"),
)

i = 1337

chat_completion = client.completions.create(
    model="mistralai/Mistral-7B-Instruct-v0.1",
    prompt="What are three words that describe the Python programming language?",
    max_tokens=20,
    stream=True,
    seed=i,
)

# iterate over the stream of messages
for message in chat_completion:
    print(message)
```


response
```
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text='\n')], created=1722373608, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text='Object')], created=1722373608, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text='-')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text='oriented')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text=',')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text=' Vers')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text='atile')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text=',')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text=' Easy')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text=' to')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text=' learn')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='', index=0, logprobs=None, text='.')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=None)
Completion(id='', choices=[CompletionChoice(finish_reason='eos_token', index=0, logprobs=None, text='</s>')], created=1722373609, model='mistralai/Mistral-7B-Instruct-v0.1', object='text_completion', system_fingerprint='2.2.1-dev0-native', usage=CompletionUsage(completion_tokens=13, prompt_tokens=12, total_tokens=25))
```