### PR TITLE
feat: prefer stop over eos_token to align with openai finish_reason

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -619,7 +619,7 @@ impl ChatCompletion {
                 message,
                 logprobs: return_logprobs
                     .then(|| ChatCompletionLogprobs::from((details.tokens, details.top_tokens))),
-                finish_reason: details.finish_reason.to_string(),
+                finish_reason: details.finish_reason.format(true),
             }],
             usage: Usage {
                 prompt_tokens: details.prefill.len() as u32,
@@ -1113,6 +1113,15 @@ impl std::fmt::Display for FinishReason {
             FinishReason::Length => write!(f, "length"),
             FinishReason::EndOfSequenceToken => write!(f, "eos_token"),
             FinishReason::StopSequence => write!(f, "stop_sequence"),
+        }
+    }
+}
+
+impl FinishReason {
+    pub fn format(&self, use_stop: bool) -> String {
+        match self {
+            FinishReason::EndOfSequenceToken if use_stop => "stop".to_string(),
+            _ => self.to_string(),
         }
     }
 }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -919,7 +919,7 @@ async fn completions(
                 total_tokens += details.prefill.len() as u32 + details.generated_tokens;
 
                 Ok(CompletionComplete {
-                    finish_reason: details.finish_reason.to_string(),
+                    finish_reason: details.finish_reason.format(true),
                     index: index as u32,
                     logprobs: None,
                     text: generation.generated_text,
@@ -1159,7 +1159,7 @@ async fn chat_completions(
                         tool_calls,
                         current_time,
                         logprobs,
-                        stream_token.details.map(|d| d.finish_reason.to_string()),
+                        stream_token.details.map(|d| d.finish_reason.format(true)),
                     ),
                 ))
                 .unwrap_or_else(|e| {


### PR DESCRIPTION
This PR aligns the `finish_reason` value with openai. Currently TGI returns the string `eos_token` rather than `stop` as a finish_reason.

Fixes: https://github.com/huggingface/text-generation-inference/issues/2296

The discrepancy between the values is easier to noticed when a strongly typed client is used. Currently the incorrect `finish_value` will cause the following request to fail since it expects `stop` rather than `eos_token`, these changes resolve this example.

```rust
use async_openai::config::OpenAIConfig;
use async_openai::types::CreateCompletionRequestArgs;
use async_openai::Client;
use std::error::Error;

#[tokio::main]
async fn main() -> Result<(), Box<dyn Error>> {
    let client = Client::with_config(OpenAIConfig::new().with_api_base("http://localhost:3000/v1"));

    let request = CreateCompletionRequestArgs::default()
        .model("meta-llama/Meta-Llama-3-8B-Instruct")
        .prompt("What is Hugging Face and what does it do?")
        .max_tokens(2000_u32) // <- increased
        .seed(1337)
        .build()?;

    let response = client.completions().create(request).await?;

    println!("\nResponse (single):\n");
    for choice in response.choices {
        println!("{}", choice.text);
    }

    Ok(())
}
```