### PR TITLE
fix: allocate tmp based on sgmv kernel if available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -226,6 +226,8 @@ COPY --from=exllamav2-kernels-builder /usr/src/build/lib.linux-x86_64-cpython-31
 COPY --from=awq-kernels-builder /usr/src/llm-awq/awq/kernels/build/lib.linux-x86_64-cpython-310 /opt/conda/lib/python3.10/site-packages
 # Copy build artifacts from eetq kernels builder
 COPY --from=eetq-kernels-builder /usr/src/eetq/build/lib.linux-x86_64-cpython-310 /opt/conda/lib/python3.10/site-packages
+# Copy build artifacts from lorax punica kernels builder
+COPY --from=lorax-punica-builder /usr/src/lorax-punica/server/punica_kernels/build/lib.linux-x86_64-cpython-310 /opt/conda/lib/python3.10/site-packages
 # Copy build artifacts from fbgemm builder
 COPY --from=fbgemm-builder /usr/src/fbgemm/fbgemm_gpu/_skbuild/linux-x86_64-3.10/cmake-install /opt/conda/lib/python3.10/site-packages
 # Copy build artifacts from vllm builder

--- a/server/text_generation_server/utils/sgmv.py
+++ b/server/text_generation_server/utils/sgmv.py
@@ -151,13 +151,17 @@ def get_tmp_expand_size(size: int) -> int:
 def get_tmp_tensors(
     nsegments: int, lora_rank: int, device: torch.device
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    if use_cutlass_shrink(lora_rank) and has_sgmv():
+    use_cutlass = use_cutlass_shrink(lora_rank) and has_sgmv()
+    has_sgmv_available = has_sgmv()
+
+    if use_cutlass:
         tmp = get_tmp_tensor_for_size(nsegments, device)
         return tmp, tmp
+    elif has_sgmv_available:
+        return get_tmp_tensor(device), get_tmp_tensor_for_size(nsegments, device)
     else:
-        tmp_shrink = get_tmp_tensor(device)
-        tmp_expand = get_tmp_tensor_for_size_no_kernels(nsegments, device)
-        return tmp_shrink, tmp_expand
+        tmp = get_tmp_tensor_for_size(nsegments, device)
+        return tmp, tmp
 
 
 def lora_a_sgmv_cutlass(


### PR DESCRIPTION
This PR improves the `get_tmp_tensors` function to correctly allocate temp tensors based on the `sgmv` kernel is availability. 

This fixes an issue where temp tensors were allocated via the non kernel path, but later checked by a kernel assert.



started
```bash
text-generation-launcher \
--model-id meta-llama/Meta-Llama-3-8B-Instruct \
--lora-adapters DavidLanz/Llama3_tw_8B_btc_qlora
```

req/rep without adapter
```bash
curl 127.0.0.1:3000/generate \
    -X POST \
    -H 'Content-Type: application/json' \
    -d '{
  "inputs": "What are three words to describe you?",
  "parameters": {
    "max_new_tokens": 20
  }
}'
# {"generated_text":" (e.g. funny, outgoing, creative)\nI would say that three words to describe me are"}
```


req/rep with adapter
```bash
curl 127.0.0.1:3000/generate \
    -X POST \
    -H 'Content-Type: application/json' \
    -d '{
  "inputs": "What are three words to describe you?",
  "parameters": {
    "max_new_tokens": 20,
    "adapter_id": "DavidLanz/Llama3_tw_8B_btc_qlora"
  }
}'
# {"generated_text":" A. Adventurous, B. Creative, C. Curious\nWhat are three words to describe"}%
```