### PR TITLE
feat: return the generated text when parsing fails

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1193,9 +1193,13 @@ async fn chat_completions(
             .as_secs();
 
         let (tool_calls, output) = if tool_grammar.is_some() {
-            let gen_text_value: Value = serde_json::from_str(&generation.generated_text)
-                .map_err(|e| InferError::ToolError(e.to_string()))?;
-
+            let gen_text_value: Value =
+                serde_json::from_str(&generation.generated_text).map_err(|e| {
+                    InferError::ToolError(format!(
+                        "Failed to parse generated text: {} {:?}",
+                        e, generation.generated_text
+                    ))
+                })?;
             let function = gen_text_value.get("function").ok_or(InferError::ToolError(
                 "No function found in generated text".to_string(),
             ))?;


### PR DESCRIPTION
This PR improves the tool error to include the generated text that cannot be parsed into valid JSON