### PR TITLE
feat: add release and sha tagged images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,6 +126,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}${{ env.LABEL }}
             type=semver,pattern={{major}}.{{minor}}${{ env.LABEL }}
+            type=semver,pattern={{major}}.{{minor}}-${{ env.GITHUB_SHA_SHORT }}${{ env.LABEL }}
             type=raw,value=latest${{ env.LABEL }},enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=raw,value=sha-${{ env.GITHUB_SHA_SHORT }}${{ env.LABEL }}
       - name: Build and push Docker image


### PR DESCRIPTION
This PR adds a new image tag to include both the latest version and sha tag on images. This is helpful in understanding which version the latest changes derive from