### PR TITLE
fix: return the out tensor rather then the functions return value

### DIFF
--- a/server/text_generation_server/layers/attention/cuda.py
+++ b/server/text_generation_server/layers/attention/cuda.py
@@ -292,8 +292,7 @@ else:
                 )
 
         out = torch.empty_like(q)
-
-        return flash_attn_cuda.fwd(
+        flash_attn_cuda.fwd(
             q,
             k,
             v,
@@ -309,4 +308,5 @@ else:
             False,
             0,
             None,
-        )[0]
+        )
+        return out


### PR DESCRIPTION
This PR fixes a bug with the output value from flash attention. Currently when using flash attention v1 the output of the `attention` function is the `[0]` indexed value returned from `flash_attn_cuda.fwd`. This tensor is not the correct shape or value and the correct return value is the `out` tensor.