### PR TITLE
Fix TypeError in get_model_with_lora_adapters due to NoneType comparison in __init__.py

### DIFF
--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -492,7 +492,13 @@ def get_model(
         )
     sliding_window = config_dict.get("sliding_window", -1)
 
-    if max_input_tokens is not None and max_input_tokens <= sliding_window:
+    if max_input_tokens is None:
+        max_input_tokens = 1024  # Set a default value if not provided
+    
+    if sliding_window is None:
+        sliding_window = 2048  # Set a default value if not provided
+
+    if max_input_tokens <= sliding_window:
         sliding_window = -1
 
     if (

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -492,13 +492,7 @@ def get_model(
         )
     sliding_window = config_dict.get("sliding_window", -1)
 
-    if max_input_tokens is None:
-        max_input_tokens = 1024  # Set a default value if not provided
-    
-    if sliding_window is None:
-        sliding_window = 2048  # Set a default value if not provided
-
-    if max_input_tokens <= sliding_window:
+    if max_input_tokens is not None and (sliding_window is None or max_input_tokens <= sliding_window):
         sliding_window = -1
 
     if (


### PR DESCRIPTION
This PR addresses an issue where a TypeError occurs due to a comparison between NoneType and int in the get_model_with_lora_adapters function. The changes ensure that the comparison logic accounts for NoneType values, thereby preventing the error and improving the robustness of the code.

Motivation and Context
The error was causing the model to fail to start when max_input_tokens or sliding_window were None. By adding default values and handling the comparison appropriately, this PR ensures the model can start correctly without encountering this issue.

Dependencies
There are no additional dependencies required for this change.