### PR TITLE
fix: prefer hidden_activation over hidden_act in gemma2

### DIFF
--- a/server/text_generation_server/models/custom_modeling/flash_gemma2_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_gemma2_modeling.py
@@ -265,7 +265,7 @@ class FlashGemma2Attention(torch.nn.Module):
 class Gemma2MLP(nn.Module):
     def __init__(self, prefix, config, weights):
         super().__init__()
-        act = config.hidden_act
+        act = config.hidden_activation
         self.act = (
             ACT2FN[act]
             if "gelu" not in act


### PR DESCRIPTION
This PR prefers the name `hidden_activation` over `hidden_act` for gemma2 models. Some models seem to have both values in their configs, but all that I checked have `hidden_activation`


https://huggingface.co/google/gemma-2-9b/blob/33c193028431c2fde6c6e51f29e6f17b60cbfac6/config.json#L14
https://huggingface.co/google/gemma-2-27b-it/blob/f6c533e5eb013c7e31fc74ef042ac4f3fb5cf40b/config.json#L14

the one without `hidden_act`
https://huggingface.co/google/shieldgemma-9b/blob/139f40846b04129a44c261c158c34ba1abe7e777/config.json#L14