### PR TITLE
fix(router): Fix appending to message content

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1017,7 +1017,7 @@ impl MessageContent {
         match self {
             MessageContent::SingleText(text) => {
                 *self =
-                    MessageContent::MultipleChunks(vec![MessageChunk::Text { text: text.clone() }]);
+                    MessageContent::MultipleChunks(vec![MessageChunk::Text { text: text.clone() }, chunk]);
             }
             MessageContent::MultipleChunks(chunks) => {
                 chunks.push(chunk);


### PR DESCRIPTION
# What does this PR do?

Fixes #2375 

When appending new chuck message to a message (for example, when using tools), the new chuck was never actually inserted. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ErikKaum
@drbh 


