### PR TITLE
fix: include create_exllama_buffers and set_device for exllama

### DIFF
--- a/server/text_generation_server/layers/gptq/__init__.py
+++ b/server/text_generation_server/layers/gptq/__init__.py
@@ -422,12 +422,16 @@ elif CAN_EXLLAMA:
         if V2:
             from text_generation_server.layers.gptq.exllamav2 import (
                 QuantLinear as ExllamaQuantLinear,  # noqa: F401
+                create_exllama_buffers,  # noqa: F401
+                set_device,  # noqa: F401
             )
 
             HAS_EXLLAMA = "2"
         else:
             from text_generation_server.layers.gptq.exllama import (
                 Ex4bitLinear as ExllamaQuantLinear,  # noqa: F401
+                create_exllama_buffers,  # noqa: F401
+                set_device,  # noqa: F401
             )
 
             HAS_EXLLAMA = "1"


### PR DESCRIPTION
This PR reimports `set_device` and `set_device` which are later used in `Warmup` https://github.com/huggingface/text-generation-inference/blob/9a7830bd287fb1ca2a3e94f208acd2eb881eb311/server/text_generation_server/server.py#L104 and the buffer is used here https://github.com/huggingface/text-generation-inference/blob/9a7830bd287fb1ca2a3e94f208acd2eb881eb311/server/text_generation_server/layers/gptq/exllamav2.py#L214

This should resolve the ex2 test cases that are receiving a None instead of the pointer to the buffer