### PR TITLE
fix: adds causal to attention params

### DIFF
--- a/server/text_generation_server/layers/attention/cuda.py
+++ b/server/text_generation_server/layers/attention/cuda.py
@@ -293,6 +293,7 @@ else:
         max_s,
         softmax_scale,
         window_size_left=-1,
+        causal=None,
         softcap=None,
     ):
         if window_size_left != -1:


### PR DESCRIPTION
This PR adds `causal=None` to `attention` for flash attention v1. 

This avoids throwing when the `causal` param is passed. and returns better errors in the case the flash attention v1 is used with `window_size_left!=-1` or `softcap not None`