### PR TITLE
fix: repack for marlin when single scale is provided

### DIFF
--- a/server/text_generation_server/layers/marlin/fp8.py
+++ b/server/text_generation_server/layers/marlin/fp8.py
@@ -38,9 +38,12 @@ class GPTQMarlinFP8Linear(nn.Module):
 
         log_once(logger.info, "GPU does not support FP8, using Marlin FP8 kernel")
 
+        # if scales is a scalar (0D tensor), convert it to a 1D tensor
+        if scales.dim() == 0:
+            scales = scales.unsqueeze(0)
+
         scales = scales.unsqueeze(0)
-        # repack weights for Marlin if a single scale is provided
-        if scales.size(0) == 1:
+        if scales.shape[1] == 1:
             out_features, in_features = qweight.shape
             scales = scales.repeat(1, out_features)
         qweight, scales = repack_fp8_for_marlin(qweight, scales)

--- a/server/text_generation_server/layers/marlin/fp8.py
+++ b/server/text_generation_server/layers/marlin/fp8.py
@@ -39,7 +39,8 @@ class GPTQMarlinFP8Linear(nn.Module):
         log_once(logger.info, "GPU does not support FP8, using Marlin FP8 kernel")
 
         scales = scales.unsqueeze(0)
-        if scales.shape[1] == 1:
+        # repack weights for Marlin if a single scale is provided
+        if scales.size(0) == 1:
             out_features, in_features = qweight.shape
             scales = scales.repeat(1, out_features)
         qweight, scales = repack_fp8_for_marlin(qweight, scales)


### PR DESCRIPTION
This PR adjust the conditional for repacking fp8 for marlin to run when a single scale is provided. This avoids a `IndexError` in the case that scales only contain a single value. 


not ~~related to: https://github.com/huggingface/text-generation-inference/issues/2388~~