### PR TITLE
fix: skip cuda graphs that will oom and improve free memory logging

### DIFF
--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -1386,7 +1386,8 @@ class FlashCausalLM(Model):
                 total_cuda_graph_memory = free_memory_post_alloc - last_available_memory
                 log_master(
                     logger.info,
-                    f"Total memory used for CUDA graphs: {total_cuda_graph_memory/1024/1024:.2f} MB",
+                    f"Total memory used for CUDA graphs: {total_cuda_graph_memory/1024/1024:.2f} MB"
+                    f"\nTotal memory available: {last_available_memory/1024/1024:.2f} MB",
                 )
             except torch.cuda.OutOfMemoryError:
                 logger.exception("Decode cuda graph warmup failed")


### PR DESCRIPTION
This PR adds logs to show the free memory amount before warmup, after cache allocation and after total cuda graph memory usage. 

Additionally this PR will skip cuda graphs (and show a warning) for graphs that will likely OOM. This happens when the model + cache allocations amount is too large to include all of the cuda graph batch sizes. (long term it would be better to accurately estimate the cuda graph size and warn users if the combination will OOM) until we can better estimate, we'll optimistically apply the cuda graphs if there is enough available memory.

Note: This PR should help avoid OOM issues with low max token amounts related to https://github.com/huggingface/hf-endpoints/pull/1410



example log output
```
Server started at unix:///tmp/text-generation-server-0
Free memory before the warmup: 6939.06 MB
Free memory after allocating the cache: 393.06 MB
Cuda Graphs are enabled for sizes [32, 16, 8, 4, 2, 1]
Total memory used for CUDA graphs: 222.00 MB
Total memory available: 171.06 MB
```

