### PR TITLE
fix(router): Fix tools not following the chat template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f7e8e35b6c7b169bf40b0176d2c79291ab8ee53290b84e0668ab21d841aa9d"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -46,7 +46,7 @@ ngrok = { version = "0.13.1", features = ["axum"], optional = true }
 init-tracing-opentelemetry = { version = "0.14.1", features = [
   "opentelemetry-otlp",
 ] }
-minijinja = { version = "2.0.2" }
+minijinja = { version = "2.0.2", features = ["json"] }
 minijinja-contrib = { version = "2.0.2", features = ["pycompat"] }
 futures-util = "0.3.30"
 regex = "1.10.3"

--- a/router/src/infer/mod.rs
+++ b/router/src/infer/mod.rs
@@ -3,7 +3,7 @@ mod chat_template;
 pub mod tool_grammar;
 
 use crate::validation::{ValidGenerateRequest, Validation, ValidationError};
-use crate::GrammarType;
+use crate::Tool;
 use crate::{
     ChatTemplateVersions, FinishReason, GenerateRequest, HubProcessorConfig, HubTokenizerConfig,
     Message, PrefillToken, Token,
@@ -140,12 +140,12 @@ impl Infer {
         &self,
         guideline: Option<String>,
         messages: Vec<Message>,
-        grammar_with_prompt: Option<(GrammarType, String)>,
+        tools_and_prompt: Option<(Option<Vec<Tool>>, String)>,
     ) -> Result<String, InferError> {
         self.chat_template
             .as_ref()
             .ok_or_else(|| InferError::TemplateError(ErrorKind::TemplateNotFound.into()))?
-            .apply(guideline.as_deref(), messages, grammar_with_prompt)
+            .apply(guideline.as_deref(), messages, tools_and_prompt)
             .map_err(|e| {
                 metrics::counter!("tgi_request_failure", "err" => "template").increment(1);
                 tracing::error!("{e}");

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -843,7 +843,7 @@ pub(crate) struct ChatRequest {
     #[serde(default = "default_tool_prompt")]
     #[schema(
         nullable = true,
-        example = "\"You will be presented with a JSON schema representing a set of tools.\nIf the user request lacks of sufficient information to make a precise tool selection: Do not invent any tool's properties, instead notify with an error message.\n\nJSON Schema:\n\""
+        example = "Given the functions available, please respond with a JSON for a function call with its proper arguments that best answers the given prompt. Respond in the format {name: function name, parameters: dictionary of argument name and its value}.Do not use variables."
     )]
     pub tool_prompt: Option<String>,
 
@@ -867,7 +867,7 @@ pub(crate) struct ChatRequest {
 
 fn default_tool_prompt() -> Option<String> {
     Some(
-        "\nYou will be presented with a JSON schema representing a set of tools.\nIf the user request lacks of sufficient information to make a precise tool selection: Do not invent any tool's properties, instead notify with an error message.\n\nJSON Schema:\n".to_string(),
+        "\nGiven the functions available, please respond with a JSON for a function call with its proper arguments that best answers the given prompt. Respond in the format {name: function name, parameters: dictionary of argument name and its value}.Do not use variables.\n".to_string(),
     )
 }
 
@@ -968,7 +968,7 @@ pub(crate) struct ChatTemplateInputs<'a> {
     bos_token: Option<&'a str>,
     eos_token: Option<&'a str>,
     add_generation_prompt: bool,
-    tools: Option<&'a str>,
+    tools: Option<Vec<Tool>>,
     tools_prompt: Option<&'a str>,
     guideline: Option<&'a str>,
 }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -2562,13 +2562,11 @@ fn prepare_chat_input(
     }
 
     // if tools are set, apply the tool grammar and then the chat template
-    let tool_grammar: Option<Tools> = ToolGrammar::apply(tools, tool_choice)?;
+    let tool_grammar: Option<Tools> = ToolGrammar::apply(tools.clone(), tool_choice)?;
     let grammar = tool_grammar
         .as_ref()
         .map(|t| GrammarType::Json(serde_json::json!(t)));
-    let tools_grammar_prompt = tool_grammar
-        .as_ref()
-        .map(|t| (GrammarType::Json(serde_json::json!(t)), tool_prompt.into()));
-    let inputs = infer.apply_chat_template(guideline, messages, tools_grammar_prompt)?;
+    let tools_and_prompt: (Option<Vec<Tool>>, String) = (tools, tool_prompt.into());
+    let inputs = infer.apply_chat_template(guideline, messages, Some(tools_and_prompt))?;
     Ok((inputs, grammar, tool_grammar))
 }


### PR DESCRIPTION
# What does this PR do?

This is a follow up on #2375. It should also cover #2413.


**Problem**:
The current version of TGI does not use the proper chat template when tools are provided and the chat template has a variable `tools`.

This PR fixes this problem by passing directly the tools to the jinja template, while keeping the compatibility for chat templates without `tools`.

See few examples below of the new functionality

<details>
  <summary><b>Example: Request</b></summary>

```
curl localhost:3000/v1/chat/completions -X POST -H 'Content-Type: application/json' -d '{
    "model": "tgi",
    "messages": [
        {
            "role": "user",
            "content": "What is the weather like in New York?"
        }
    ],
    "tools": [
        {
            "type": "function",
            "function": {
                "name": "get_current_weather",
                "description": "Get the current weather",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "location": {
                            "type": "string",
                            "description": "The city and state, e.g. San Francisco, CA"
                        },
                        "format": {
                            "type": "string",
                            "enum": ["celsius", "fahrenheit"],
                            "description": "The temperature unit to use. Infer this from the users location."
                        }
                    },
                    "required": ["location", "format"]
                }
            }
        }
    ],
    "tool_choice": "auto",
    "temperature": 0 
}'
```
</details>

<details>
  <summary><b>Example: Tool-enabled model (mistralai/mistral-7b-instruct-v0.3)</b></summary>

Formatted prompt
```
2024-08-22T16:36:02.510140Z DEBUG chat_completions: text_generation_router::server: 
router/src/server.rs:296: Input: <s>[AVAILABLE_TOOLS] [{"type": "function", "function": {"arguments": 
{"properties":{"format":{"description":"The temperature unit to use. Infer this from the users 
location.","enum":["celsius","fahrenheit"],"type":"string"},"location":{"description":"The city and 
state, e.g. San Francisco, CA","type":"string"}},"required":["location","format"],"type":"object"}, 
"description": "Get the current weather", "name": "get_current_weather"}}][/AVAILABLE_TOOLS][INST] 
What is the weather like in New York?
---

Given the functions available, please respond with a JSON for a function call with its proper 
arguments that best answers the given prompt. Respond in the format {name: function name, parameters: 
dictionary of argument name and its value}.Do not use variables. 
[/INST]
```

Output:
```
{"object":"chat.completion","id":"","created":1724344563,"model":"mistralai/Mistral-7B-Instruct-v0.3",
"system_fingerprint":"2.2.1-dev0-native", "choices":[{"index":0,"message":
{"role":"assistant","tool_calls":[{"id":"0","type":"function","function":{"description":null,"name":"get_current_weather",
"arguments":{"format":"celsius","location":"New York"}}}]},"logprobs":null,"finish_reason":"stop"}],
"usage":{"prompt_tokens":184,"completion_tokens":32,"total_tokens":216}}
```

</details>

<details>
  <summary><b>Example: Tool-enabled model (meta-llama/meta-llama-3.1-8B-instruct)</b></summary>

Formatted input:
```
2024-08-22T16:58:52.248514Z DEBUG chat_completions: text_generation_router::server: router/src/server.rs:296: 
Input: <|begin_of_text|><|start_header_id|>system<|end_header_id|>

Environment: ipython
Cutting Knowledge Date: December 2023
Today Date: 26 Jul 2024

<|eot_id|><|start_header_id|>user<|end_header_id|>

Given the following functions, please respond with a JSON for a function call with its proper 
arguments that best answers the given prompt.

Respond in the format {"name": function name, "parameters": dictionary of argument name and its 
value}.Do not use variables.

{
    "function": {
        "arguments": {
            "properties": {
                "format": {
                    "description": "The temperature unit to use. Infer this from the users location.",
                    "enum": [
                        "celsius",
                        "fahrenheit"
                    ],
                    "type": "string"
                },
                "location": {
                    "description": "The city and state, e.g. San Francisco, CA",
                    "type": "string"
                }
            },
            "required": [
                "location",
                "format"
            ],
            "type": "object"
        },
        "description": "Get the current weather",
        "name": "get_current_weather"
    },
    "type": "function"
}

What is the weather like in New York?
---

Given the functions available, please respond with a JSON for a function call with its proper 
arguments that best answers the given prompt. Respond in the format {name: function name, parameters: 
dictionary of argument name and its value}.Do not use variables.<|eot_id|>
<|start_header_id|>assistant<|end_header_id|>
```

Output:

```
{"object":"chat.completion","id":"","created":1724345932,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct",
"system_fingerprint":"2.2.1-dev0-native","choices":[{"index":0,"message":
{"role":"assistant","tool_calls":[{"id":"0","type":"function","function":
{"description":null,"name":"get_current_weather","arguments":
{"format":"celsius","location":"New York"}}}]},"
logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":303,"completion_tokens":27,"total_tokens":330}}
``` 
</details>

<details>
  <summary><b>Example: Not tool-enabled model (mistralai/mistral-7b-instruct-v0.2)</b></summary>

Formatted input:
```
2024-08-22T17:06:34.283426Z DEBUG chat_completions: text_generation_router::server: router/src/server.rs:296: 
Input: <s> [INST] What is the weather like in New York?
---
Some([Tool { type: "function", function: FunctionDefinition { description: Some("Get the current 
weather"), name: "get_current_weather", arguments: Object {"properties": Object {"format": Object 
{"description": String("The temperature unit to use. Infer this from the users location."), "enum": 
Array [String("celsius"), String("fahrenheit")], "type": String("string")}, "location": Object 
{"description": String("The city and state, e.g. San Francisco, CA"), "type": String("string")}}, 
"required": Array [String("location"), String("format")], "type": String("object")} } }])

Given the functions available, please respond with a JSON for a function call with its proper 
arguments that best answers the given prompt. Respond in the format {name: function name, parameters: 
dictionary of argument name and its value}.Do not use variables.
[/INST]
```

Output:
```
{"object":"chat.completion","id":"","created":1724346394,"model":"mistralai/Mistral-7B-Instruct-v0.2",
"system_fingerprint":"2.2.1-dev0-native","choices":[{"index":0,"message":
{"role":"assistant","tool_calls":[{"id":"0","type":"function","function":
{"description":null,"name":"get_current_weather","arguments":{"format":"celsius","location":"New 
York"}}}]},"logprobs":null,"finish_reason":"stop"}],"usage":
{"prompt_tokens":221,"completion_tokens":41,"total_tokens":262}}
```

</details>

*Note 1*: This PR changes a bit the logic for the `tool_grammar`. Please, make sure it's not breaking anything somewhere else.

*Note 2*: The default tool template is a bit ugly, there might be a better way to "serialize" the tools.

*Note 3*: The `notify_error` tool (added in the tool grammar) is not in the prompt (but it should be).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ErikKaum 
@drbh 
