### PR TITLE
fix: enable chat requests in vertex endpoint

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -55,11 +55,18 @@ impl std::str::FromStr for Attention {
 }
 
 #[derive(Clone, Deserialize, ToSchema)]
-pub(crate) struct VertexInstance {
+pub(crate) struct GenerateVertexInstance {
     #[schema(example = "What is Deep Learning?")]
     pub inputs: String,
     #[schema(nullable = true, default = "null", example = "null")]
     pub parameters: Option<GenerateParameters>,
+}
+
+#[derive(Clone, Deserialize, ToSchema)]
+#[serde(untagged)]
+enum VertexInstance {
+    Generate(GenerateVertexInstance),
+    Chat(ChatRequest),
 }
 
 #[derive(Deserialize, ToSchema)]


### PR DESCRIPTION
This PR adds the 


```python
import requests
import json

url = 'http://127.0.0.1:3000/vertex'

payload = {
    "instances": [
        {
            "messages": [{"role": "user", "content": "What's Deep Learning?"}],
            "parameters": {
                "max_new_tokens": 128,
                "do_sample": True,
                "top_p": 0.95,
                "temperature": 0.7
            }
        }
    ]
}

headers = {
    'Content-Type': 'application/json'
}

response = requests.post(url, data=json.dumps(payload), headers=headers)


print(response.text)
```

```json
{
    "predictions": [
        "Deep Learning (DL) is a subfield of Machine Learning (ML) that involves the use of artificial neural networks (ANNs) with multiple layers to analyze and interpret complex data. The term "deep" refers to the fact that these neural networks typically have many more layers than traditional ML models.\n\nKey characteristics of Deep Learning:\n\n1. **Artificial Neural Networks (ANNs)**: Inspired by the structure and function of the human brain, ANNs consist of layers of interconnected nodes (neurons"
    ]
}
```