### PR TITLE
Add links to Adyen blogpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ overridden with the `--otlp-service-name` argument
 
 ![TGI architecture](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/TGI.png)
 
-Detailed blogpost by Adyen on TGI inner workings: [LLM inference at scale with TGI](https://www.adyen.com/knowledge-hub/llm-inference-at-scale-with-tgi)
+Detailed blogpost by Adyen on TGI inner workings: [LLM inference at scale with TGI (Martin Iglesias Goyanes - Adyen, 2024)](https://www.adyen.com/knowledge-hub/llm-inference-at-scale-with-tgi)
 
 ### Local install
 

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -72,7 +72,7 @@
   - local: conceptual/lora
     title: LoRA (Low-Rank Adaptation)
   - local: conceptual/external
-    title: External sources
+    title: External Resources
 
 
   title: Conceptual Guides

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -71,6 +71,8 @@
     title: How Guidance Works (via outlines)
   - local: conceptual/lora
     title: LoRA (Low-Rank Adaptation)
+  - local: conceptual/external
+    title: External sources
 
 
   title: Conceptual Guides

--- a/docs/source/conceptual/external.md
+++ b/docs/source/conceptual/external.md
@@ -1,0 +1,4 @@
+# External sources
+
+- Adyen wrote a detailed article about the interplay between TGI's main components: router and server.
+[LLM inference at scale with TGI (Martin Iglesias Goyanes - Adyen, 2024)](https://www.adyen.com/knowledge-hub/llm-inference-at-scale-with-tgi)

--- a/docs/source/conceptual/external.md
+++ b/docs/source/conceptual/external.md
@@ -1,4 +1,4 @@
-# External sources
+# External Resources
 
 - Adyen wrote a detailed article about the interplay between TGI's main components: router and server.
 [LLM inference at scale with TGI (Martin Iglesias Goyanes - Adyen, 2024)](https://www.adyen.com/knowledge-hub/llm-inference-at-scale-with-tgi)

--- a/docs/source/conceptual/streaming.md
+++ b/docs/source/conceptual/streaming.md
@@ -155,7 +155,3 @@ SSEs are different than:
 * Webhooks: where there is a bi-directional connection. The server can send information to the client, but the client can also send data to the server after the first request. Webhooks are more complex to operate as they don’t only use HTTP.
 
 If there are too many requests at the same time, TGI returns an HTTP Error with an `overloaded` error type (`huggingface_hub` returns `OverloadedError`). This allows the client to manage the overloaded server (e.g., it could display a busy error to the user or retry with a new request). To configure the maximum number of concurrent requests, you can specify `--max_concurrent_requests`, allowing clients to handle backpressure.
-
-## External sources
-
-Adyen wrote a nice recap of how TGI streaming feature works. [LLM inference at scale with TGI](https://www.adyen.com/knowledge-hub/llm-inference-at-scale-with-tgi)


### PR DESCRIPTION
I feel this setup makes more sense since the blogpost was not really talking about Streaming or any of the concepts you already have inside the "Conceptual Guides". Instead, it gives more of a holistic view of the architecture and the interplay between server and router. 

I created this new section "External" for cases like this, ideally in the future the list of articles in "External" will grow as TGI adoption grows.

Eager to hear your feedback @Narsil 