### PR TITLE
hotfix: ipex fails since cuda moe kernel is not supported

### DIFF
--- a/server/text_generation_server/models/custom_modeling/flash_deepseek_v2_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_deepseek_v2_modeling.py
@@ -15,7 +15,6 @@
 
 from typing import List, Optional, Tuple
 
-from moe_kernels.fused_moe import grouped_topk
 import torch
 import torch.distributed
 from text_generation_server.layers import (
@@ -40,6 +39,9 @@ from text_generation_server.utils.weights import Weights
 from torch import nn
 from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig
+
+if SYSTEM != "ipex":
+    from moe_kernels.fused_moe import grouped_topk
 
 if SYSTEM == "rocm":
     try:


### PR DESCRIPTION
error like
"Could not import Flash Attention enabled models: No module named 'moe_kernels'"

@danieldk @ErikKaum @Narsil please help review and merge it. thanks