### PR TITLE
Remove duplicated `RUN` in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ COPY router router
 COPY backends backends
 COPY launcher launcher
 RUN cargo build --profile release-opt
-RUN cargo build --profile release-opt
 
 # Python builder
 # Adapted from: https://github.com/pytorch/pytorch/blob/master/Dockerfile


### PR DESCRIPTION
# What does this PR do?

This PR removes `RUN cargo build --profile release-opt` command as it's duplicated within the CUDA `Dockerfile`.

## Who can review?

@OlivierDehaene OR @Narsil
