### PR TITLE
Adding note for private models in quick-tour document

### DIFF
--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -16,10 +16,12 @@ docker run --gpus all --shm-size 1g -p 8080:80 -v $volume:/data \
 ```
 
 <Tip>
+
 If you’re looking to serve gated or private models, which provide
 controlled access to sensitive or proprietary content, check out
 [this guide](https://huggingface.co/docs/text-generation-inference/en/basic_tutorials/gated_model_access)
 for detailed instructions.
+
 </Tip>
 
 ### Supported hardware

--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -17,7 +17,7 @@ docker run --gpus all --shm-size 1g -p 8080:80 -v $volume:/data \
 
 <Tip>
 
-If you’re looking to serve gated or private models, which provide
+If you want to serve gated or private models, which provide
 controlled access to sensitive or proprietary content, check out
 [this guide](https://huggingface.co/docs/text-generation-inference/en/basic_tutorials/gated_model_access)
 for detailed instructions.

--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -15,6 +15,13 @@ docker run --gpus all --shm-size 1g -p 8080:80 -v $volume:/data \
     --model-id $model
 ```
 
+<Tip>
+If you’re looking to serve gated or private models, which provide
+controlled access to sensitive or proprietary content, check out
+[this guide](https://huggingface.co/docs/text-generation-inference/en/basic_tutorials/gated_model_access)
+for detailed instructions.
+</Tip>
+
 ### Supported hardware
 
 TGI supports various hardware. Make sure to check the [Using TGI with Nvidia GPUs](./installation_nvidia), [Using TGI with AMD GPUs](./installation_amd), [Using TGI with Intel GPUs](./installation_intel), [Using TGI with Gaudi](./installation_gaudi), [Using TGI with Inferentia](./installation_inferentia) guides depending on which hardware you would like to deploy TGI on.

--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -18,7 +18,7 @@ docker run --gpus all --shm-size 1g -p 8080:80 -v $volume:/data \
 <Tip>
 
 If you want to serve gated or private models, which provide
-controlled access to sensitive or proprietary content, check out
+controlled access to sensitive or proprietary content, refer to
 [this guide](https://huggingface.co/docs/text-generation-inference/en/basic_tutorials/gated_model_access)
 for detailed instructions.
 


### PR DESCRIPTION
This PR adds a note and a hyperlink to the [Serving Private & Gated Models](https://huggingface.co/docs/text-generation-inference/en/basic_tutorials/gated_model_access) page inside the [Quick Tour](https://huggingface.co/docs/text-generation-inference/en/quicktour) page.

 Since ‘Quick Tour’ serves as a landing page for many beginners, this addition will help those looking to serve their private or gated models locally.