### PR TITLE
Fix build with `--features google`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,3 +58,6 @@ jobs:
       - name: Run Rust tests
         run: |
           cargo test
+      - name: Run Rust tests with google feature
+        run: |
+          cargo test --features google

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -2029,7 +2029,8 @@ async fn start(
 
     #[cfg(feature = "google")]
     {
-        use crate::VertexInstance;
+        use crate::vertex::__path_vertex_compatibility;
+        use crate::vertex::{VertexInstance, VertexRequest, VertexResponse};
 
         #[derive(OpenApi)]
         #[openapi(


### PR DESCRIPTION
# What does this PR do?

As of recent changes within the Vertex AI integration via the `google` feature, the build via `cargo build --features google` was not working fine; this PR fixes that.

## Who can review?

@Narsil