### PR TITLE
Update `ToolType` input schema

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2114,12 +2114,18 @@
       "ToolType": {
         "oneOf": [
           {
-            "type": "object",
-            "default": null,
-            "nullable": true
+            "type": "string",
+            "description": "Means the model can pick between generating a message or calling one or more tools.",
+            "enum": [
+              "auto"
+            ]
           },
           {
-            "type": "string"
+            "type": "string",
+            "description": "Means the model will not call any tool and instead generates a message.",
+            "enum": [
+              "none"
+            ]
           },
           {
             "type": "object",
@@ -2131,13 +2137,10 @@
                 "$ref": "#/components/schemas/FunctionName"
               }
             }
-          },
-          {
-            "type": "object",
-            "default": null,
-            "nullable": true
           }
-        ]
+        ],
+        "description": "Controls which (if any) tool is called by the model.",
+        "example": "auto"
       },
       "Url": {
         "type": "object",

--- a/router/src/infer/tool_grammar.rs
+++ b/router/src/infer/tool_grammar.rs
@@ -53,10 +53,7 @@ impl ToolGrammar {
 
         // if tools are provided and no tool_choice we default to the OneOf
         let tools_to_use = match tool_choice {
-            ToolType::FunctionName(name) => {
-                vec![Self::find_tool_by_name(&tools, &name)?]
-            }
-            ToolType::Function { function } => {
+            ToolType::Function ( function ) => {
                 vec![Self::find_tool_by_name(&tools, &function.name)?]
             }
             ToolType::OneOf => tools.clone(),

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -957,12 +957,18 @@ pub fn default_tool_prompt() -> String {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
-#[serde(untagged)]
+#[schema(example = "auto")]
+/// Controls which (if any) tool is called by the model.
 pub enum ToolType {
+    /// Means the model can pick between generating a message or calling one or more tools.
+    #[schema(rename = "auto")]
     OneOf,
-    FunctionName(String),
-    Function { function: FunctionName },
+    /// Means the model will not call any tool and instead generates a message.
+    #[schema(rename = "none")]
     NoTool,
+    /// Forces the model to call a specific tool.
+    #[schema(rename = "function")]
+    Function(FunctionName),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -987,7 +993,9 @@ impl From<ToolTypeDeserializer> for ToolChoice {
             ToolTypeDeserializer::String(s) => match s.as_str() {
                 "none" => ToolChoice(Some(ToolType::NoTool)),
                 "auto" => ToolChoice(Some(ToolType::OneOf)),
-                _ => ToolChoice(Some(ToolType::FunctionName(s))),
+                _ => ToolChoice(Some(ToolType::Function(FunctionName {
+                        name: s
+                } ))),
             },
             ToolTypeDeserializer::ToolType(tool_type) => ToolChoice(Some(tool_type)),
         }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -993,9 +993,7 @@ impl From<ToolTypeDeserializer> for ToolChoice {
             ToolTypeDeserializer::String(s) => match s.as_str() {
                 "none" => ToolChoice(Some(ToolType::NoTool)),
                 "auto" => ToolChoice(Some(ToolType::OneOf)),
-                _ => ToolChoice(Some(ToolType::Function(FunctionName {
-                        name: s
-                } ))),
+                _ => ToolChoice(Some(ToolType::Function(FunctionName{name: s}))),
             },
             ToolTypeDeserializer::ToolType(tool_type) => ToolChoice(Some(tool_type)),
         }


### PR DESCRIPTION
See related slack [thread](https://huggingface.slack.com/archives/C05CFK1HM0T/p1727340352681279) (private).

The goal of this PR is to improve the ToolType specs in [openapi.json](https://github.com/huggingface/text-generation-inference/blob/d18ed5cfc5f404dd7e8c1d719e8293e713c1fb4c/docs/openapi.json#L2114). At the moment, the `ToolType::NoTool` and `ToolType::OneOf` are wrongly typed as 
```
{
  "type": "object",
  "default": null,
  "nullable": true
},
```

instead of a string enum with values `none`/`auto`.

For what I understood, `#[serde(untagged)]` doesn't play well when the possible values are either an object or a string enum value. At least I did not managed to get it right.

**What I did in this PR is:**
- remove `#[serde(untagged)]`
- rename `NoTool` to `none`
- rename `OneOf` to `auto`
- remove the "any string is supported" (`FunctionName(String)`) from the `ToolType` enum. I think this is here for backward compatibility but it is not a proper argument in the [OpenAI reference](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice)
- still accept "any string" and parse it into a `Function` object as if it was provided as a function object. This means we still support "any string" but won't have it in the official specs.
- added some docs (examples and descriptions)

This PR seems to be compiling and generating the correct openapi specs but I haven't tested it properly.

**Also related:**
Based on [OpenAI reference](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice), possible values are `none` (i.e. don't use tools), `auto` (i.e. you _can_ use a tool), `required` (i.e. you _must_ use a tool) and `{"type": "function", "function": {"name": "my_function"}}` (i.e. you _must_ use this specific tool).
- we support `none` => OK
- we support `auto` using `OneOf` => I'm actually not sure if the `OneOf` logic a "can use" or "must use"
- we don't support `required` => out of scope for this PR
- when passing an object, we don't require and we don't handle `"type": "function"` => out of scope for this PR