### PR TITLE
nix: add black and isort to the closure

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -27,3 +27,6 @@ asyncio_mode = "auto"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+profile = "black"

--- a/integration-tests/pyproject.toml
+++ b/integration-tests/pyproject.toml
@@ -13,3 +13,6 @@ pytest = "^7.4.0"
 pytest-asyncio = "^0.21.1"
 docker = "^7"
 numpy = "^1.20"
+
+[tool.isort]
+profile = "black"

--- a/nix/impure-shell.nix
+++ b/nix/impure-shell.nix
@@ -1,5 +1,7 @@
 {
   mkShell,
+  black,
+  isort,
   openssl,
   pkg-config,
   protobuf,
@@ -14,6 +16,8 @@
 mkShell {
   buildInputs =
     [
+      black
+      isort
       openssl.dev
       pkg-config
       (rust-bin.stable.latest.default.override {

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -82,3 +82,6 @@ requires = [
     "poetry-core>=1.0.0",
 ]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
# What does this PR do?

To make sure that everything is formatted with the same `black` version as CI.

I sometimes use `isort` for new files to get nicely ordered imports, so add it as well. Also set the `isort` configuration to format in a way that is compatible with `black`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
