### PR TITLE
Fix the tool_choice format for named choice by adapting OpenAIs scheme

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2137,6 +2137,24 @@
                 "$ref": "#/components/schemas/FunctionName"
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "function"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "function"
+                ]
+              },
+              "function": {
+                "$ref": "#/components/schemas/FunctionName"
+              }
+            }
           }
         ],
         "description": "Controls which (if any) tool is called by the model.",

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -968,7 +968,16 @@ pub enum ToolType {
     NoTool,
     /// Forces the model to call a specific tool.
     #[schema(rename = "function")]
+    #[serde(alias = "function")]
     Function(FunctionName),
+}
+
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type")]
+pub enum TypedChoice {
+    #[serde(rename = "function")]
+    Function{function: FunctionName},
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -986,7 +995,9 @@ enum ToolTypeDeserializer {
     Null,
     String(String),
     ToolType(ToolType),
+    TypedChoice(TypedChoice) //this is the OpenAI schema
 }
+
 
 impl From<ToolTypeDeserializer> for ToolChoice {
     fn from(value: ToolTypeDeserializer) -> Self {
@@ -997,6 +1008,7 @@ impl From<ToolTypeDeserializer> for ToolChoice {
                 "auto" => ToolChoice(Some(ToolType::OneOf)),
                 _ => ToolChoice(Some(ToolType::Function(FunctionName { name: s }))),
             },
+            ToolTypeDeserializer::TypedChoice(TypedChoice::Function{function}) => ToolChoice(Some(ToolType::Function(function))),
             ToolTypeDeserializer::ToolType(tool_type) => ToolChoice(Some(tool_type)),
         }
     }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1616,4 +1616,36 @@ mod tests {
             r#"{"role":"assistant","tool_calls":[{"id":"0","type":"function","function":{"description":null,"name":"myfn","arguments":{"format":"csv"}}}]}"#
         );
     }
+
+    #[test]
+    fn tool_choice_formats() {
+
+        #[derive(Deserialize)]
+        struct TestRequest {
+            tool_choice: ToolChoice,
+        }
+
+        let none = r#"{"tool_choice":"none"}"#;
+        let de_none: TestRequest = serde_json::from_str(none).unwrap();
+        assert_eq!(de_none.tool_choice, ToolChoice(Some(ToolType::NoTool)));
+
+        let auto = r#"{"tool_choice":"auto"}"#;
+        let de_auto: TestRequest = serde_json::from_str(auto).unwrap();
+        assert_eq!(de_auto.tool_choice, ToolChoice(Some(ToolType::OneOf)));
+
+        let ref_choice = ToolChoice(Some(ToolType::Function(FunctionName { name: "myfn".to_string() })));
+
+        let named = r#"{"tool_choice":"myfn"}"#;
+        let de_named: TestRequest = serde_json::from_str(named).unwrap();
+        assert_eq!(de_named.tool_choice, ref_choice);
+
+        let old_named = r#"{"tool_choice":{"function":{"name":"myfn"}}}"#;
+        let de_old_named: TestRequest = serde_json::from_str(old_named).unwrap();
+        assert_eq!(de_old_named.tool_choice, ref_choice);
+
+        let openai_named = r#"{"tool_choice":{"type":"function","function":{"name":"myfn"}}}"#;
+        let de_openai_named: TestRequest = serde_json::from_str(openai_named).unwrap();
+
+        assert_eq!(de_openai_named.tool_choice, ref_choice);
+    }
 }


### PR DESCRIPTION
This pull request resolves an issue with the ToolChoice/ToolType struct. 
Currently, the API does not allow the OpenAI tool_choice schemes. Currently, the API expects this format to force the usage of an explicit tool:
```
"tool_choice": {
    "Function": {
         "name": "function_name"
    }
}
```
 (or "tool_choice": “function_name”). Both are incompatible with the [OpenAI format](https://platform.openai.com/docs/guides/function-calling/configuring-function-calling-behavior-using-the-tool_choice-parameter).

This pull request changes two things:
1. Keyword “Function” → “function”
2. adding the OpenAI schema for named choices:
```
"tool_choice": {
    "type": "function",
    "function": {
         "name": "function_name"
    }
}
```
@Narsil

