### PR TITLE
remove docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -295,8 +295,5 @@ ENTRYPOINT ["./entrypoint.sh"]
 # Final image
 FROM base
 
-COPY ./tgi-entrypoint.sh /tgi-entrypoint.sh
-RUN chmod +x /tgi-entrypoint.sh
-
-ENTRYPOINT ["/tgi-entrypoint.sh"]
+ENTRYPOINT ["text-generation-launcher"]
 # CMD ["--json-output"]

--- a/Dockerfile_amd
+++ b/Dockerfile_amd
@@ -330,8 +330,5 @@ ENV ATTENTION=paged
 ENV USE_PREFIX_CACHING=0
 ENV ROCM_USE_SKINNY_GEMM=1
 
-COPY ./tgi-entrypoint.sh /tgi-entrypoint.sh
-RUN chmod +x /tgi-entrypoint.sh
-
-ENTRYPOINT ["/tgi-entrypoint.sh"]
+ENTRYPOINT ["text-generation-launcher"]
 CMD ["--json-output"]

--- a/tgi-entrypoint.sh
+++ b/tgi-entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-ldconfig 2>/dev/null || echo 'unable to refresh ld cache, not a big deal in most cases'
-
-text-generation-launcher $@


### PR DESCRIPTION
this entrypoint was meant to fix tgi on some cloud providers like gcp that do not ensure the ld cache is refreshed after adding some shared libraries in custom container hooks

this should not belong to tgi repo itself

cc @co42 @christophe-rannou @Narsil 