### PR TITLE
fix: prefer inplace softmax to avoid copy

### DIFF
--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -1922,8 +1922,9 @@ class FlashCausalLM(Model):
             batch.adapter_meta.adapter_indices = next_adapter_indices
 
         if prefill and prefill_logprobs:
-            # Get prefill logprobs
-            prefill_logprobs_tensor = torch.log_softmax(out, -1)
+            # Get prefill logprobs with inplace softmax (avoid copying the `out` tensor (max_batch_size * vocab_size))
+            torch.log_softmax(out, -1, out=out)
+            prefill_logprobs_tensor = out
             prefill_logprobs = torch.gather(
                 prefill_logprobs_tensor, 1, prefill_tokens_indices.view(-1, 1)
             )


### PR DESCRIPTION
This PR modifies `log_softmax` to operate in place, eliminating the need to copy large tensors. This optimization reduces memory consumption during warmup.

For instance, when using `meta-llama/Meta-Llama-3.1-8B-Instruct` on an L4, this change allows running the model with `--max-batch-prefill-tokens` increased from 7192 to 9874 without exceeding memory limits