### PR TITLE
fix tgi-entrypoint wrapper in docker file: exec instead of spawning a child process

### DIFF
--- a/tgi-entrypoint.sh
+++ b/tgi-entrypoint.sh
@@ -2,4 +2,4 @@
 
 ldconfig 2>/dev/null || echo 'unable to refresh ld cache, not a big deal in most cases'
 
-text-generation-launcher $@
+exec text-generation-launcher $@


### PR DESCRIPTION
reason: we added a docker wrapper script a while ago to fix missing .so issues encountered when spawning tgi in some cloud providers that add shared libs, related to cuda for example, but do not refresh the ld cache in container hooks. tgi was spawned as a child process instead of replacing the parent one (the process bound to the script iself). Thus, the wrapper script was receiving all the signals and we forgot to add proper handlers to forward them to the child. The parent/child mechanism is overkill in this case and we can just replace the wrapper by tgi once the cache is refreshed