### PR TITLE
Add support for stop words in TRTLLM 

### DIFF
--- a/Dockerfile_trtllm
+++ b/Dockerfile_trtllm
@@ -43,7 +43,7 @@ RUN wget "https://download.open-mpi.org/release/open-mpi/v4.1/$OMPI_TARBALL_FILE
     mkdir /usr/src/mpi && \
     tar -xf "/opt/src/$OMPI_TARBALL_FILENAME" -C /usr/src/mpi --strip-components=1 && \
     cd /usr/src/mpi && \
-    ./configure --prefix=/usr/local/mpi --with-cuda=/usr/local/cuda && \
+    ./configure --prefix=/usr/local/mpi --with-cuda=/usr/local/cuda --with-slurm && \
     make -j all && \
     make install && \
     rm -rf "/opt/src/$OMPI_TARBALL_FILENAME"

--- a/Dockerfile_trtllm
+++ b/Dockerfile_trtllm
@@ -84,7 +84,7 @@ RUN mkdir $TGI_INSTALL_PREFIX && mkdir "$TGI_INSTALL_PREFIX/include" && mkdir "$
     CMAKE_INSTALL_PREFIX=$TGI_INSTALL_PREFIX cargo build --release
 
 FROM nvidia/cuda:12.6.1-cudnn-runtime-ubuntu22.04 AS runtime
-RUN apt update && apt install -y python3 && \
+RUN apt update && apt install -y python3-minimal python3-dev && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 WORKDIR /usr/local/tgi/bin

--- a/Dockerfile_trtllm
+++ b/Dockerfile_trtllm
@@ -84,8 +84,9 @@ RUN mkdir $TGI_INSTALL_PREFIX && mkdir "$TGI_INSTALL_PREFIX/include" && mkdir "$
     CMAKE_INSTALL_PREFIX=$TGI_INSTALL_PREFIX cargo build --release
 
 FROM nvidia/cuda:12.6.1-cudnn-runtime-ubuntu22.04 AS runtime
-RUN apt update && apt install -y python3-minimal python3-dev && \
-    rm -rf /var/lib/{apt,dpkg,cache,log}/
+RUN apt update && apt install -y python3-minimal python3-dev python3-pip && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/ && \
+    python3 -m pip install transformers tokenizers
 
 WORKDIR /usr/local/tgi/bin
 

--- a/Dockerfile_trtllm
+++ b/Dockerfile_trtllm
@@ -89,7 +89,7 @@ RUN apt update && apt install -y python3-minimal python3-dev && \
 
 WORKDIR /usr/local/tgi/bin
 
-ENV LD_LIBRARY_PATH="/usr/local/tgi/lib:/usr/local/tensorrt/lib:/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="/usr/local/tgi/lib:/usr/local/mpi/lib:/usr/local/tensorrt/lib:/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH"
 ENV TOKENIZERS_PARALLELISM=false
 ENV OMPI_MCA_plm_rsh_agent=""
 

--- a/backends/trtllm/include/backend.h
+++ b/backends/trtllm/include/backend.h
@@ -44,23 +44,7 @@ namespace huggingface::tgi::backends {
     /**
      * Initialize logging mechanism
      */
-    void InitializeLogging() {
-#ifdef NDEBUG
-        if (const auto TRTLLM_LOG_LEVEL_CSTR = std::getenv("TRTLLM_LOG_LEVEL")) {
-        std::string log_level(TRTLLM_LOG_LEVEL_CSTR);
-        std::transform(log_level.begin(), log_level.end(), log_level.begin(), [](unsigned char c) {
-            return std::tolower(c);
-        });
-
-        if (log_level == "debug")
-            spdlog::set_level(spdlog::level::debug);
-        else
-            spdlog::set_level(spdlog::level::info);
-    }
-#else
-        spdlog::set_level(spdlog::level::debug);
-#endif
-    }
+    void InitializeLogging();
 
 
     /**

--- a/backends/trtllm/include/backend.h
+++ b/backends/trtllm/include/backend.h
@@ -44,7 +44,7 @@ namespace huggingface::tgi::backends {
     /**
      * Initialize logging mechanism
      */
-    void huggingface::tgi::backends::InitializeLogging() {
+    void InitializeLogging() {
 #ifdef NDEBUG
         if (const auto TRTLLM_LOG_LEVEL_CSTR = std::getenv("TRTLLM_LOG_LEVEL")) {
         std::string log_level(TRTLLM_LOG_LEVEL_CSTR);

--- a/backends/trtllm/include/backend.h
+++ b/backends/trtllm/include/backend.h
@@ -20,6 +20,9 @@
 using json = nlohmann::json;
 namespace tle = tensorrt_llm::executor;
 
+
+#define CAST_SIZETYPE(x) static_cast<tle::SizeType32>(x)
+
 namespace huggingface::tgi::backends {
     using RequestId = tle::IdType;
     using TokenId = tle::TokenIdType;

--- a/backends/trtllm/include/backend.h
+++ b/backends/trtllm/include/backend.h
@@ -5,6 +5,7 @@
 #ifndef TGI_TRTLLM_BACKEND_H
 #define TGI_TRTLLM_BACKEND_H
 
+#include <array>
 #include <cmath>
 #include <filesystem>
 #include <span>
@@ -72,6 +73,7 @@ namespace huggingface::tgi::backends {
 
         /** Frequently accessed variables cached here **/
         uint32_t maxNumTokens;
+        std::list<std::vector<TokenId>> stopWords;
 
     public:
         explicit TensorRtLlmBackend(
@@ -91,20 +93,20 @@ namespace huggingface::tgi::backends {
          * @param topK
          * @param topP
          * @param temperature
-         * @param repetition_penalty
-         * @param frequency_penalty
+         * @param repetitionPenalty
+         * @param frequencyPenalty
          * @param seed
          * @return Request id related to this generation for reference
          */
         [[nodiscard]] RequestId Submit(
                 const std::vector<TokenId> &tokens,
-                const uint32_t maxNewTokens,
-                const int32_t topK,
-                const float_t topP,
-                const float_t temperature,
-                const float_t repetition_penalty,
-                const float_t frequency_penalty,
-                const uint64_t seed
+                uint32_t maxNewTokens,
+                int32_t topK,
+                float_t topP,
+                float_t temperature,
+                float_t repetitionPenalty,
+                float_t frequencyPenalty,
+                uint64_t seed
         );
 
         [[nodiscard]] std::vector<tle::Response> PullNewTokens();

--- a/backends/trtllm/include/backend.h
+++ b/backends/trtllm/include/backend.h
@@ -83,6 +83,14 @@ namespace huggingface::tgi::backends {
     ) noexcept;
 
     /**
+     * Attempt to retrieve the
+     * @param generationConfigPath
+     * @return
+     */
+    std::optional<std::list<std::vector<TokenId>>>
+    GetStopWordsFromConfig(const std::filesystem::path &generationConfigPath) noexcept;
+
+    /**
      *
      */
     class TensorRtLlmBackend {

--- a/backends/trtllm/include/hardware.h
+++ b/backends/trtllm/include/hardware.h
@@ -23,9 +23,9 @@ namespace huggingface::hardware::cuda {
         int32_t major;
         int32_t minor;
 
-        [[nodiscard]] constexpr bool isPostAmpere() const { return major >= AMPERE_SM_MAJOR; }
+        [[nodiscard]] constexpr bool IsPostAmpere() const { return major >= AMPERE_SM_MAJOR; }
 
-        [[nodiscard]] constexpr bool isPostHopper() const { return major >= HOPPER_SM_MAJOR; }
+        [[nodiscard]] constexpr bool IsPostHopper() const { return major >= HOPPER_SM_MAJOR; }
     };
 
     CudaComputeCapabilities GetCudaComputeCapabilities() {

--- a/backends/trtllm/lib/backend.cpp
+++ b/backends/trtllm/lib/backend.cpp
@@ -24,7 +24,8 @@ void huggingface::tgi::backends::InitializeBackend() {
     }
 }
 
-[[nodiscard]] tle::ParallelConfig GetParallelConfig(const size_t worldSize, std::string workerPath) {
+[[nodiscard]]
+tle::ParallelConfig GetParallelConfig(const size_t worldSize, std::string workerPath) {
     auto mode = tle::CommunicationMode::kLEADER;
     std::optional<tle::OrchestratorConfig> orchestratorConfig = std::nullopt;
 

--- a/backends/trtllm/lib/backend.cpp
+++ b/backends/trtllm/lib/backend.cpp
@@ -164,10 +164,9 @@ tle::IdType huggingface::tgi::backends::TensorRtLlmBackend::Submit(
 #endif
 
     const auto sampling = GetSamplingConfig(topK, topP, temperature, repetitionPenalty, frequencyPenalty, seed);
-    const auto maxNewTokensChecked_ = static_cast<tle::SizeType32>(maxNewTokensChecked);
 
     // Build the request
-    auto request = tle::Request{tokens, maxNewTokensChecked_, true, sampling, OUTPUT_CONFIG};
+    auto request = tle::Request{tokens, CAST_SIZETYPE(maxNewTokensChecked), true, sampling, OUTPUT_CONFIG};
     request.setStopWords(stopWords);
 
     // Submit to the executor for batching

--- a/backends/trtllm/lib/backend.cpp
+++ b/backends/trtllm/lib/backend.cpp
@@ -53,6 +53,7 @@ tle::ExecutorConfig huggingface::tgi::backends::GetExecutorConfig(const json &co
     // Define some configuration variables
     execConfig.setKvCacheConfig(tle::KvCacheConfig(true));
     execConfig.setEnableChunkedContext(computeCapabilities.isPostAmpere());
+    execConfig.setSchedulerConfig(tle::SchedulerConfig(tle::CapacitySchedulerPolicy::kMAX_UTILIZATION));
     return execConfig;
 }
 

--- a/backends/trtllm/src/ffi.cpp
+++ b/backends/trtllm/src/ffi.cpp
@@ -23,9 +23,14 @@ huggingface::tgi::backends::TensorRtLlmBackendImpl::TensorRtLlmBackendImpl(
 
 
 uint64_t huggingface::tgi::backends::TensorRtLlmBackendImpl::Submit(
-        rust::Slice<const uint32_t> tokens, uint32_t maxNewTokens,
-        int32_t topK, float_t topP, float_t temperature,
-        float_t repetition_penalty, float_t frequency_penalty, uint64_t seed) {
+        rust::Slice<const uint32_t> tokens,
+        uint32_t maxNewTokens,
+        int32_t topK,
+        float_t topP,
+        float_t temperature,
+        float_t repetition_penalty,
+        float_t frequency_penalty,
+        uint64_t seed) {
 
     // This will copy all the items from the initial slice
     std::vector<int32_t> tokens_(tokens.begin(), tokens.end());

--- a/backends/trtllm/src/looper.rs
+++ b/backends/trtllm/src/looper.rs
@@ -27,11 +27,6 @@ use crate::utils::first_line;
 
 type InferResult<T> = Result<T, InferError>;
 
-struct IdentifiableRequest<T> {
-    request_id: u64,
-    inner: T,
-}
-
 /// Wrap the requests along with the channel used to stream back to the client the decoded tokens
 struct GenerationContext {
     request: ValidGenerateRequest,

--- a/backends/trtllm/src/looper.rs
+++ b/backends/trtllm/src/looper.rs
@@ -387,9 +387,7 @@ impl Backend for TensorRtLlmBackendV2 {
         }
     }
 
-    async fn health(&self, current_health: bool) -> bool {
-        current_health
-            & !self.executor_looper.is_finished()
-            & !self.post_processor_looper.is_finished()
+    async fn health(&self, _: bool) -> bool {
+        !self.executor_looper.is_finished() & !self.post_processor_looper.is_finished()
     }
 }


### PR DESCRIPTION
[MERGE AFTER #2357]

This PR attempts to read the `eos_token_ids` in `generation_config.json` (if present) and creates a list (`std::list` required by trtllm) to cache those value.

The list is then forwarded to TRTLLM's executor during request submission.

Known issues:
- stop words added at request time through `stop_sequences` are not yet supported 