### PR TITLE
Support OpenAI Structured Output by adding json_schema as an alias for JSON Grammar

### DIFF
--- a/integration-tests/models/__snapshots__/test_structured_output_response_format_llama/test_structured_output_response_format_llama_json.json
+++ b/integration-tests/models/__snapshots__/test_structured_output_response_format_llama/test_structured_output_response_format_llama_json.json
@@ -1,0 +1,23 @@
+{
+  "choices": [
+    {
+      "finish_reason": "eos_token",
+      "index": 0,
+      "logprobs": null,
+      "message": {
+        "content": "{\n  \"temperature\": [\n    35,\n    34,\n    36\n  ],\n  \"unit\": \"°c\"\n}",
+        "role": "assistant"
+      }
+    }
+  ],
+  "created": 1718044128,
+  "id": "",
+  "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+  "object": "text_completion",
+  "system_fingerprint": "2.0.5-dev0-native",
+  "usage": {
+    "completion_tokens": 39,
+    "prompt_tokens": 136,
+    "total_tokens": 175
+  }
+}

--- a/integration-tests/models/test_structured_output_response_format_llama.py
+++ b/integration-tests/models/test_structured_output_response_format_llama.py
@@ -1,0 +1,102 @@
+import pytest
+import requests
+from pydantic import BaseModel
+from typing import List
+
+
+@pytest.fixture(scope="module")
+def llama_grammar_handle(launcher):
+    with launcher(
+        "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        num_shard=1,
+        disable_grammar_support=False,
+        use_flash_attention=False,
+        max_batch_prefill_tokens=3000,
+    ) as handle:
+        yield handle
+
+
+@pytest.fixture(scope="module")
+async def llama_grammar(llama_grammar_handle):
+    await llama_grammar_handle.health(300)
+    return llama_grammar_handle.client
+
+
+@pytest.mark.release
+@pytest.mark.asyncio
+async def test_structured_output_response_format_llama_json(llama_grammar, response_snapshot):
+    class Weather(BaseModel):
+        unit: str
+        temperature: List[int]
+
+    # send the request
+    response = requests.post(
+        f"{llama_grammar.base_url}/v1/chat/completions",
+        headers=llama_grammar.headers,
+        json={
+            "model": "tgi",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": f"Respond to the users questions and answer them in the following format: {Weather.schema()}",
+                },
+                {
+                    "role": "user",
+                    "content": "What's the weather like the next 3 days in San Francisco, CA?",
+                },
+            ],
+            "seed": 42,
+            "max_tokens": 500,
+            "response_format": {"type": "json_schema", "value": Weather.schema()},
+        },
+    )
+
+    chat_completion = response.json()
+    called = chat_completion["choices"][0]["message"]["content"]
+
+    assert response.status_code == 200
+    assert (
+        called
+        == '{\n  "temperature": [\n    35,\n    34,\n    36\n  ],\n  "unit": "°c"\n}'
+    )
+    assert chat_completion == response_snapshot
+
+
+@pytest.mark.release
+@pytest.mark.asyncio
+async def test_structured_output_response_format_llama_error_if_tools_not_installed(
+    llama_grammar,
+):
+    class Weather(BaseModel):
+        unit: str
+        temperature: List[int]
+
+    # send the request
+    response = requests.post(
+        f"{llama_grammar.base_url}/v1/chat/completions",
+        headers=llama_grammar.headers,
+        json={
+            "model": "tgi",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": f"Respond to the users questions and answer them in the following format: {Weather.schema()}",
+                },
+                {
+                    "role": "user",
+                    "content": "What's the weather like the next 3 days in San Francisco, CA?",
+                },
+            ],
+            "seed": 42,
+            "max_tokens": 500,
+            "tools": [],
+            "response_format": {"type": "json_schema", "value": Weather.schema()},
+        },
+    )
+
+    # 422 means the server was unable to process the request because it contains invalid data.
+    assert response.status_code == 422
+    assert response.json() == {
+        "error": "Tool error: Grammar and tools are mutually exclusive",
+        "error_type": "tool_error",
+    }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -120,7 +120,7 @@ pub(crate) enum GrammarType {
     /// JSON Schema is a declarative language that allows to annotate JSON documents
     /// with types and descriptions.
     #[serde(rename = "json")]
-    #[serde(alias = "json_object")]
+    #[serde(alias = "json_object", alias = "json_schema")]
     #[schema(example = json ! ({"properties": {"location":{"type": "string"}}}))]
     Json(serde_json::Value),
     #[serde(rename = "regex")]


### PR DESCRIPTION
# What does this PR do?

### tl;dr
Supports `"json_schema"` for as a type for `response_format` in addition to the existing alias of `"json_object"` and `"json"`. This aligns TGI with the OpenAI API and builds on the updates from #2046 .  vLLM recently added support for this as well: https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/protocol.py#L326

### Explanation

OpenAI recently released support for [Structured Output](https://platform.openai.com/docs/guides/structured-outputs/introduction) (in their words, an "evolved" version of JSON mode). The OpenAI API now permits the passing of a response format type `json_schema`. The OpenAI Python Client now accepts a Pydantic Model Class directly via `response_format` and then contains logic that passes the model JSON's schema with the type `"json_schema"` (see here: https://github.com/openai/openai-python/blob/main/src/openai/lib/_parsing/_completions.py#L258). 

To make things even more interesting, the OpenAI beta client also contains logic on the other end to deserialize the response into an object of that class (as shown here: https://platform.openai.com/docs/guides/structured-outputs/introduction)

With this change, passing a Pydantic class directly as a response_format will be supported:
```python

from openai import OpenAI
client = OpenAI(
    base_url="http://<host>:<port>/v1/",
    api_key="...",
)

class AnimalDescription(BaseModel):
    """The structured description of animal's attributes ."""
    num_eyes: int = Field(..., description="Number of eyes for this animal.")
    num_limbs: int = Field(..., description="Number of limbs (arms, legs) for this animal.")
    sea_animal: bool = Field(..., description="Whether or not this animal inhabits the sea.")
    species_name: str = Field(..., description="Binomial nomenclature for this animal.")
    common_habitats: List[str] = Field(
        ..., description="A list of regions where this animal is known to inhabit."
    )

def answer_with_structured_output() -> None:
    chat_completion = client.beta.chat.completions.parse(
        messages=[
            {"role": "system", "content": "You are a helpful assistant who is very knowledgeable about animals." },
            {"role": "user", "content": "Can you do some research and give me a report about Lions, in the JSON format provided."}
        ],
        model="tgi",
        max_tokens=1000,
        response_format=AnimalDescription
    )

    result = chat_completion.choices[0].message.content
```

The server will still continue to support the types as `"json"` or `"json_object"` like:
```python
response_format={"type": "json_object", "value": AnimalDescription.model_json_schema()}
```  

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Big fan of TGI, thank you!
