### PR TITLE
fix qwen2 vl failure in intel cpu and xpu

### DIFF
--- a/server/text_generation_server/models/custom_modeling/qwen2_vl.py
+++ b/server/text_generation_server/models/custom_modeling/qwen2_vl.py
@@ -505,5 +505,7 @@ class Qwen2VLForConditionalGeneration(nn.Module):
             prefill_cache_indices=prefill_cache_indices,
         )
         hidden_states, _ = self.norm(hidden_states)
+        if lm_head_indices is not None:
+            hidden_states = hidden_states[lm_head_indices]
         logits = self.lm_head(hidden_states)
         return logits, None


### PR DESCRIPTION
Hi, I see your guys have added qwen2 vl into tgi, and I try the model in intel cpu, and find it does not work, failure like

data: {"error":"Request failed during generation: Server error: output with shape [1] doesn't match the broadcast shape [873]","error_type":"generation"}

I debug it and find following code is missing in modeling and cause prefill output shape is not as expected.

@drbh  @Narsil please help review it