### PR TITLE
fix: create position ids for text only input

### DIFF
--- a/server/text_generation_server/models/custom_modeling/qwen2_vl.py
+++ b/server/text_generation_server/models/custom_modeling/qwen2_vl.py
@@ -468,7 +468,12 @@ class Qwen2VLForConditionalGeneration(nn.Module):
 
             llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
             position_ids[:, i, :] = llm_positions.to(position_ids.device)
-
+        else:
+            position_ids = (
+                torch.arange(batch_input_ids.shape[1], device=batch_input_ids.device)
+                .view(1, 1, -1)
+                .expand(3, batch_input_ids.shape[0], -1)
+            )
         return position_ids
 
     def forward(

--- a/server/text_generation_server/models/custom_modeling/qwen2_vl.py
+++ b/server/text_generation_server/models/custom_modeling/qwen2_vl.py
@@ -472,7 +472,7 @@ class Qwen2VLForConditionalGeneration(nn.Module):
             position_ids = (
                 torch.arange(batch_input_ids.shape[1], device=batch_input_ids.device)
                 .view(1, 1, -1)
-                .expand(3, batch_input_ids.shape[0], -1)
+                .repeat(3, batch_input_ids.shape[0], 1)
             )
         return position_ids
 


### PR DESCRIPTION
This PR adds the `else` for text only requests with qwen2-vl. Longer term position ids should be simplified and consolidated - however this change fixes text only generation in the current implementation of qwen2-vl