### PR TITLE
Incomplete generation stream fix

### DIFF
--- a/backends/v3/src/backend.rs
+++ b/backends/v3/src/backend.rs
@@ -369,11 +369,6 @@ async fn filter_batch(
 ) -> Option<CachedBatch> {
     let mut batch = next_batch?;
 
-    // No need to filter
-    if batch.size as usize == entries.len() {
-        return Some(batch);
-    }
-
     let id = batch.id;
 
     // Retain only requests that are still in entries


### PR DESCRIPTION
server launch baichuan-inc/Baichuan2-13B-Chat 

using vllm to test tgi backend, command like
python benchmark_serving.py --backend tgi --model baichuan-inc/Baichuan2-13B-Chat --trust-remote-code --dataset-name random --random-input-len 1024 --random-output-len 128 --request-rate inf --num-prompts 100 --endpoint /generate_stream --host 0.0.0.0 --port 80 --seed 10

server hangs, log like
2024-11-18T08:46:35.673546Z ERROR text_generation_router::server: router/src/server.rs:656: Incomplete generation stream
2024-11-18T08:46:35.673576Z ERROR text_generation_router::server: router/src/server.rs:656: Incomplete generation stream

