### PR TITLE
fix: adjust llama MLP name from dense to mlp to correctly apply lora

### DIFF
--- a/server/text_generation_server/models/custom_modeling/flash_llama_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_llama_modeling.py
@@ -422,7 +422,7 @@ class FlashLlamaLayer(nn.Module):
                 if SparseMoELayer.is_supported(weights)
                 else DenseMoELayer
             )
-            self.dense = Phi3MoE(
+            self.mlp = Phi3MoE(
                 f"{prefix}.block_sparse_moe", config, moe_layer_cls, weights
             )
             # with moe the layernorms are are not rmsnorms and they have bias
@@ -437,7 +437,7 @@ class FlashLlamaLayer(nn.Module):
                 eps=config.rms_norm_eps,
             )
         else:
-            self.dense = LlamaMLP(
+            self.mlp = LlamaMLP(
                 prefix=f"{prefix}.mlp", config=config, weights=weights, index=index
             )
             self.input_layernorm = FastRMSNorm.load(
@@ -493,7 +493,7 @@ class FlashLlamaLayer(nn.Module):
             attn_output, res
         )
 
-        mlp_output = self.dense(normed_attn_res_output, adapter_data)
+        mlp_output = self.mlp(normed_attn_res_output, adapter_data)
         if self.residual_multiplier is not None:
             mlp_output *= self.residual_multiplier
 


### PR DESCRIPTION
This PR simply renames `self.dense` to `self.mlp` to fix a bug when applying lora's to llama models. As mentioned in the original bug report `get_mlp_weights` failed to apply the lora in the case no `mlp` attr existed on the layer. This PR fixes this issue with llama based models

Bug indicated here: https://github.com/huggingface/text-generation-inference/issues/2715