### PR TITLE
Remove guideline from API

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -994,13 +994,6 @@
             "example": "1.0",
             "nullable": true
           },
-          "guideline": {
-            "type": "string",
-            "description": "A guideline to be used in the chat_template",
-            "default": "null",
-            "example": "null",
-            "nullable": true
-          },
           "logit_bias": {
             "type": "array",
             "items": {

--- a/router/src/infer/mod.rs
+++ b/router/src/infer/mod.rs
@@ -159,14 +159,13 @@ impl Infer {
     #[instrument(skip_all)]
     pub(crate) fn apply_chat_template(
         &self,
-        guideline: Option<String>,
         messages: Vec<Message>,
         tools_and_prompt: Option<(Vec<Tool>, String)>,
     ) -> Result<String, InferError> {
         self.chat_template
             .as_ref()
             .ok_or_else(|| InferError::TemplateError(ErrorKind::TemplateNotFound.into()))?
-            .apply(guideline.as_deref(), messages, tools_and_prompt)
+            .apply(messages, tools_and_prompt)
             .map_err(|e| {
                 metrics::counter!("tgi_request_failure", "err" => "template").increment(1);
                 tracing::error!("{e}");

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -909,11 +909,6 @@ pub(crate) struct ChatRequest {
     #[schema(nullable = true, default = "null", example = "null")]
     pub response_format: Option<GrammarType>,
 
-    /// A guideline to be used in the chat_template
-    #[serde(default)]
-    #[schema(nullable = true, default = "null", example = "null")]
-    pub guideline: Option<String>,
-
     /// Options for streaming response. Only set this when you set stream: true.
     #[serde(default)]
     #[schema(nullable = true, example = "null")]
@@ -934,7 +929,6 @@ impl ChatRequest {
             tool_prompt,
             temperature,
             response_format,
-            guideline,
             presence_penalty,
             frequency_penalty,
             top_p,
@@ -962,7 +956,7 @@ impl ChatRequest {
 
         let (inputs, grammar, using_tools) = match response_format {
             Some(format) => {
-                let inputs = infer.apply_chat_template(guideline, messages, None)?;
+                let inputs = infer.apply_chat_template(messages, None)?;
                 (inputs, Some(format), false)
             }
             None => {
@@ -971,7 +965,6 @@ impl ChatRequest {
                         Some((updated_tools, tool_schema)) => {
                             let grammar = GrammarType::Json(serde_json::json!(tool_schema));
                             let inputs: String = infer.apply_chat_template(
-                                guideline,
                                 messages,
                                 Some((updated_tools, tool_prompt)),
                             )?;
@@ -979,13 +972,13 @@ impl ChatRequest {
                         }
                         None => {
                             // same as if no response_format or tools are set
-                            let inputs = infer.apply_chat_template(guideline, messages, None)?;
+                            let inputs = infer.apply_chat_template(messages, None)?;
                             (inputs, None, false)
                         }
                     }
                 } else {
                     // if no response_format or tools are set simply apply the chat template to generate inputs
-                    let inputs = infer.apply_chat_template(guideline, messages, None)?;
+                    let inputs = infer.apply_chat_template(messages, None)?;
                     (inputs, None, false)
                 }
             }
@@ -1163,7 +1156,6 @@ pub(crate) struct ChatTemplateInputs<'a> {
     eos_token: Option<&'a str>,
     add_generation_prompt: bool,
     tools: Option<Vec<Tool>>,
-    guideline: Option<&'a str>,
 }
 
 #[derive(Clone, Deserialize, Serialize, ToSchema, Default, Debug, PartialEq)]


### PR DESCRIPTION
This PR removes the `guideline` parameter from the API. This parameter was needed only for ShieldGemma models. In the end, the chat template of these models have been updated so they don't need this variable anymore. See [slack thread](https://huggingface.slack.com/archives/C05CFK1HM0T/p1724868036794659?thread_ts=1724852501.099809&cid=C05CFK1HM0T) for more context (internal).

Note that I made sure the project still builds correctly + updated openapi.json from the CLI but I did not ensure any backward compatibility. Please let me know how to proceed if we want to keep a deprecated argument. To be honest, my main concern is to remove `guideline` from the openapi.json so that TGI api stays on-par with the specs (and the inference clients).


Related PRs:
- https://github.com/huggingface/text-generation-inference/pull/2391
- https://github.com/huggingface/text-generation-inference/pull/2403

cc @Rocketknight1 @drbh @Narsil 