### PR TITLE
fix: set outlines version to 0.1.3 to avoid caching serialization issue

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -34,7 +34,7 @@ peft = { version = "^0.10", optional = true }
 torch = { version = "^2.4.0", optional = true }
 scipy = "^1.11.1"
 pillow = "^10.0.0"
-outlines= { version = "^0.1.1", optional = true }
+outlines= { version = "0.1.3", optional = true }
 prometheus-client = ">=0.20.0,<0.22"
 py-cpuinfo = "^9.0.0"
 compressed-tensors = { version = "^0.7.1", optional = true }


### PR DESCRIPTION
This PR fixes the outline version to `0.1.3` to avoid a bug introduced in `0.1.4` when attempting to cache the tokenizer

related: https://github.com/dottxt-ai/outlines/issues/1274 and https://github.com/dottxt-ai/outlines-core/issues/95