### PR TITLE
fix: tweak grammar test response

### DIFF
--- a/integration-tests/models/__snapshots__/test_grammar_response_format_llama/test_grammar_response_format_llama_json.json
+++ b/integration-tests/models/__snapshots__/test_grammar_response_format_llama/test_grammar_response_format_llama_json.json
@@ -5,7 +5,7 @@
       "index": 0,
       "logprobs": null,
       "message": {
-        "content": "{\n  \"temperature\": [\n    35,\n    34,\n    36\n  ],\n  \"unit\": \"°c\"\n}",
+        "content": "{ \"temperature\": [ 26, 30, 33, 29 ] ,\"unit\": \"Fahrenheit\" }",
         "role": "assistant"
       }
     }

--- a/integration-tests/models/test_grammar_response_format_llama.py
+++ b/integration-tests/models/test_grammar_response_format_llama.py
@@ -55,10 +55,7 @@ async def test_grammar_response_format_llama_json(llama_grammar, response_snapsh
     called = chat_completion["choices"][0]["message"]["content"]
 
     assert response.status_code == 200
-    assert (
-        called
-        == '{\n  "temperature": [\n    35,\n    34,\n    36\n  ],\n  "unit": "°c"\n}'
-    )
+    assert called == '{ "temperature": [ 26, 30, 33, 29 ] ,"unit": "Fahrenheit" }'
     assert chat_completion == response_snapshot
 
 


### PR DESCRIPTION
This PR simply updates the expected output and snapshot for one of the grammar tests. 

It appears this was introduced when we last bumped transformers https://github.com/huggingface/text-generation-inference/actions/runs/11856766221/job/33044166471