### PR TITLE
feat: concat the adapter id to the model id in chat response

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1228,6 +1228,7 @@ pub(crate) async fn chat_completions(
     let span = tracing::Span::current();
     metrics::counter!("tgi_request_count").increment(1);
     let ChatRequest {
+        model,
         stream,
         stream_options,
         logprobs,
@@ -1238,8 +1239,11 @@ pub(crate) async fn chat_completions(
 
     let logprobs = logprobs.unwrap_or_default();
 
-    // static values that will be returned in all cases
-    let model_id = info.model_id.clone();
+    // extract model id from request if specified
+    let model_id = match model.as_deref() {
+        Some("tgi") | None => info.model_id.clone(),
+        Some(m_id) => format!("{}+{}", info.model_id, m_id),
+    };
     let system_fingerprint = format!("{}-{}", info.version, info.docker_label.unwrap_or("native"));
     // switch on stream
     if stream {


### PR DESCRIPTION
This PR concatenates the adapter id to the model id when an adapter id is specified in the chat request.

the follwing request 
```bash
curl http: //localhost:3000/v1/chat/completions \
    -X POST \
    -H 'Content-Type: application/json' \
    -d '{
    "model": "google-cloud-partnership/gemma-2-2b-it-lora-jap-en",
    "messages": [
        {
            "content": "たくさんお金を稼ぎましたか？ Translate: ",
            "role": "user"
        }
    ],
    "max_tokens": 10,
    "stream": false
}' | jq
```

currently returns
```json
{
    "object": "chat.completion",
    "id": "",
    "created": 1732545871,
    "model": "google/gemma-2-2b-it",
    "system_fingerprint": "2.4.2-dev0-native",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "Have you made a fortune?"
            },
            "logprobs": null,
            "finish_reason": "stop"
        }
    ],
    "usage": {
        "prompt_tokens": 19,
        "completion_tokens": 7,
        "total_tokens": 26
    }
}
```

and with the changes returns an updated model id

```json
{
    "object": "chat.completion",
    "id": "",
    "created": 1732545871,
    "model": "google/gemma-2-2b-it+google-cloud-partnership/gemma-2-2b-it-lora-jap-en",
    "system_fingerprint": "2.4.2-dev0-native",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "Have you made a fortune?"
            },
            "logprobs": null,
            "finish_reason": "stop"
        }
    ],
    "usage": {
        "prompt_tokens": 19,
        "completion_tokens": 7,
        "total_tokens": 26
    }
}
```