### PR TITLE
fix lora failure in platform which does not contain punica_kernels

### DIFF
--- a/server/text_generation_server/adapters/lora.py
+++ b/server/text_generation_server/adapters/lora.py
@@ -331,16 +331,13 @@ class BatchLoraWeights(BatchAdapterWeights):
             for idx in segment_indices
             if idx in adapter_weights
         }
-        use_sgmv = False
-        rank_data = {}
-
         if not has_sgmv():
             return BatchLoraWeights(
                 lora_a=lora_a,
                 lora_b=lora_b,
                 adapter_index_configs=adapter_index_configs,
-                rank_data=rank_data,
-                use_sgmv=use_sgmv,
+                rank_data={},
+                use_sgmv=False,
             )
         if prefill or max_rank > BGMV_MAX_RANK:
             use_sgmv = True


### PR DESCRIPTION
error like
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/cli.py", line 117, in serve
    server.serve(
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/server.py", line 315, in serve
    asyncio.run(
  File "/opt/conda/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
  File "/opt/conda/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/opt/conda/lib/python3.11/asyncio/base_events.py", line 641, in run_until_complete
    self.run_forever()
  File "/opt/conda/lib/python3.11/asyncio/base_events.py", line 608, in run_forever
    self._run_once()
  File "/opt/conda/lib/python3.11/asyncio/base_events.py", line 1936, in _run_once
    handle._run()
  File "/opt/conda/lib/python3.11/asyncio/events.py", line 84, in _run
    self._context.run(self._callback, *self._args)
  File "/opt/conda/lib/python3.11/site-packages/grpc_interceptor/server.py", line 165, in invoke_intercept_method
    return await self.intercept(
> File "/opt/conda/lib/python3.11/site-packages/text_generation_server/interceptor.py", line 24, in intercept
    return await response
  File "/opt/conda/lib/python3.11/site-packages/opentelemetry/instrumentation/grpc/_aio_server.py", line 120, in _unary_interceptor
    raise error
  File "/opt/conda/lib/python3.11/site-packages/opentelemetry/instrumentation/grpc/_aio_server.py", line 111, in _unary_interceptor
    return await behavior(request_or_iterator, context)
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/server.py", line 183, in Prefill
    generations, next_batch, timings = self.model.generate_token(batch)
  File "/opt/conda/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/models/flash_causal_lm.py", line 1902, in generate_token
    adapter_data = AdapterBatchData.from_meta(
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/adapters/weights.py", line 117, in from_meta
    data[k] = v.get_data(
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/adapters/weights.py", line 89, in get_data
    batched_weights = batch_type.load(
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/adapters/lora.py", line 426, in load
    tmp_shrink, tmp_expand = get_tmp_tensors(
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/utils/sgmv.py", line 163, in get_tmp_tensors
    tmp = get_tmp_tensor_for_size(nsegments, device)
  File "/opt/conda/lib/python3.11/site-packages/text_generation_server/utils/sgmv.py", line 139, in get_tmp_tensor_for_size
    tmp_size = _kernels.sgmv_cutlass_tmp_size(size)
AttributeError: 'NoneType' object has no attribute 'sgmv_cutlass_tmp_size'