### PR TITLE
Install `text-generation-server` from `poetry.lock` export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 COPY --from=pytorch-install /opt/conda /opt/conda
 
 # Export text-generation-server Python requirements from poetry lock file
-FROM poetry-install AS poetry-requirements
+FROM conda-install AS poetry-requirements
 
 COPY server/poetry.lock poetry.lock
 COPY server/pyproject.toml pyproject.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -211,7 +211,7 @@ RUN pip install poetry && poetry export -f requirements.txt  \
 FROM conda-install AS base
 
 # Copy the requirements file generated from the poetry lock
-COPY --from=poetry-requirements /usr/src/requirements_poetry.txt requirements_poetry.txt
+COPY --from=poetry-requirements /usr/src/requirements_poetry.txt server/requirements_poetry.txt
 
 # Copy build artifacts from flash attention builder
 COPY --from=flash-att-builder /usr/src/flash-attention/build/lib.linux-x86_64-cpython-311 /opt/conda/lib/python3.11/site-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -204,9 +204,11 @@ FROM conda-install AS poetry-requirements
 COPY server/poetry.lock poetry.lock
 COPY server/pyproject.toml pyproject.toml
 
-RUN pip install poetry && poetry export -f requirements.txt  \
-    --extras "attention bnb accelerate compressed-tensors marlin moe quantize peft outlines" \
-    --output requirements_poetry.txt
+RUN pip install poetry && \
+    poetry self add poetry-plugin-export && \
+    poetry export -f requirements.txt \
+        --extras "attention bnb accelerate compressed-tensors marlin moe quantize peft outlines" \
+        --output requirements_poetry.txt
 
 FROM conda-install AS base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,7 @@ COPY server/poetry.lock poetry.lock
 COPY server/pyproject.toml pyproject.toml
 
 RUN pip install poetry && poetry export -f requirements.txt  \
-    --extras "attention, bnb, accelerate, compressed-tensors, marlin, moe, quantize, peft, outlines" \
+    --extras "attention bnb accelerate compressed-tensors marlin moe quantize peft outlines" \
     --output requirements_poetry.txt
 
 FROM conda-install AS base


### PR DESCRIPTION
# What does this PR do?

This PR installs the `text-generation-server` Python requirements from an exported `requirements.txt`-like file generated out of the `poetry.lock`, to be able to reuse the generated lock with the pinned dependencies and avoid dependency issues or conflicts when building outdated Dockerfiles in case any dependency is loose, as any potential conflict is always solved before the release and the lock is always working.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guidelines](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

cc @OlivierDehaene
