### PR TITLE
fix: include add_special_tokens in kserve request

### DIFF
--- a/router/src/kserve.rs
+++ b/router/src/kserve.rs
@@ -205,6 +205,7 @@ pub async fn kserve_model_infer(
             let generate_request = GenerateRequest {
                 inputs: str_input.to_string(),
                 parameters: payload.parameters.clone(),
+                add_special_tokens: true,
             };
             let infer = infer.clone();
             let compute_type = compute_type.clone();
@@ -212,7 +213,7 @@ pub async fn kserve_model_infer(
             async move {
                 generate_internal(infer, compute_type, Json(generate_request), span)
                     .await
-                    .map(|(_, Json(generation))| {
+                    .map(|(_, _, Json(generation))| {
                         let generation_as_bytes = generation.generated_text.as_bytes().to_vec();
                         OutputChunk {
                             name: output.name.clone(),


### PR DESCRIPTION
This PR simply adds the `add_special_tokens: true` argument to the kserve feature. This was manually being patched in a Dockerfile but should be updated upstream. https://github.com/huggingface/kserve-containers/blob/d0f206036968e5b9fae3a1037e9b0534bf145564/containers/tgi/gpu/2.4.1/Dockerfile#L49