### PR TITLE
:memo: add guide on using TPU with TGI in the docs

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -13,6 +13,8 @@
     title: Using TGI with Intel Gaudi
   - local: installation_inferentia
     title: Using TGI with AWS Inferentia
+  - local: installation_tpu
+    title: Using TGI with Google TPU
   - local: installation_intel
     title: Using TGI with Intel GPUs
   - local: installation

--- a/docs/source/installation_tpu.md
+++ b/docs/source/installation_tpu.md
@@ -1,0 +1,3 @@
+# Using TGI with Google TPU
+
+Check out this [guide](https://huggingface.co/docs/optimum-tpu) on how to serve models with TGI on TPUs.


### PR DESCRIPTION
# What does this PR do?

Update the docs to add a link to optimum-tpu. 

This is similar to the current AWS inferentia link in the doc
https://huggingface.co/docs/text-generation-inference/en/installation_inferentia