### PR TITLE
Fix typo in TPU docs

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -14,7 +14,7 @@
   - local: installation_inferentia
     title: Using TGI with AWS Inferentia
   - local: installation_tpu
-    title: Using TGI with Google TPU
+    title: Using TGI with Google TPUs
   - local: installation_intel
     title: Using TGI with Intel GPUs
   - local: installation

--- a/docs/source/installation_tpu.md
+++ b/docs/source/installation_tpu.md
@@ -1,3 +1,3 @@
-# Using TGI with Google TPU
+# Using TGI with Google TPUs
 
 Check out this [guide](https://huggingface.co/docs/optimum-tpu) on how to serve models with TGI on TPUs.


### PR DESCRIPTION
# What does this PR do?

Changed  `Using TGI with Google TPU` to `Using TGI with Google TPUs`

@alvarobartt I merged the previous PR on my phone and did not see your comments 🫣 here is a fix for the typos

Related to 
https://github.com/huggingface/text-generation-inference/pull/2907

