### PR TITLE
fix the crash of meta-llama/Llama-3.2-1B

### DIFF
--- a/server/text_generation_server/models/custom_modeling/flash_llama_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_llama_modeling.py
@@ -634,18 +634,15 @@ class FlashLlamaForCausalLM(torch.nn.Module):
             weights=weights,
         )
         if config.tie_word_embeddings:
-            prefix = "model.embed_tokens"
+            suffix = "model.embed_tokens"
         else:
             suffix = "lm_head"
-            prefix = (
-                "lm_head" if not prefix or name != "model" else f"{prefix}.{suffix}"
-            )
 
         # Used in Granite
         embedding_multiplier = getattr(config, "embedding_multiplier", None)
         if embedding_multiplier is not None:
             self.embed_tokens.weight.data *= embedding_multiplier
-
+        prefix = suffix if not prefix or name != "model" else f"{prefix}.{suffix}"
         with no_fp8(weights):
             self.lm_head = SpeculativeHead.load(
                 config,

--- a/server/text_generation_server/models/custom_modeling/flash_llama_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_llama_modeling.py
@@ -634,16 +634,17 @@ class FlashLlamaForCausalLM(torch.nn.Module):
             weights=weights,
         )
         if config.tie_word_embeddings:
-            suffix = "model.embed_tokens"
+            prefix = "model.embed_tokens"
         else:
             suffix = "lm_head"
+            prefix = (
+                "lm_head" if not prefix or name != "model" else f"{prefix}.{suffix}"
+            )
 
         # Used in Granite
         embedding_multiplier = getattr(config, "embedding_multiplier", None)
         if embedding_multiplier is not None:
             self.embed_tokens.weight.data *= embedding_multiplier
-
-        prefix = "lm_head" if not prefix or name != "model" else f"{prefix}.{suffix}"
 
         with no_fp8(weights):
             self.lm_head = SpeculativeHead.load(


### PR DESCRIPTION
fix crash of meta-llama/Llama-3.2-1B

                                                                             │
│ /opt/conda/lib/python3.11/site-packages/text_generation_server/utils/weights │
│ .py:192 in get_filename                                                      │
│                                                                              │
│   189 │   │   │   │   filename = self.routing.get(alias, None)               │
│   190 │   │   │   │   if filename is not None:                               │
│   191 │   │   │   │   │   return str(filename), alias                        │
│ ❱ 192 │   │   raise RuntimeError(f"weight {tensor_name} does not exist")     │
│   193 │                                                                      │
│   194 │   def _get_slice(self, tensor_name: str):                            │
│   195 │   │   filename, tensor_name = self.get_filename(tensor_name)         │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │     aliases = []                                                         │ │
│ │    filename = None                                                       │ │
│ │        name = 'lm_head.weight'                                           │ │
│ │       names = ['lm_head.weight']                                         │ │
│ │        self = <text_generation_server.utils.weights.Weights object at    │ │
│ │               0x7f998b64b9d0>                                            │ │
│ │ tensor_name = 'lm_head.weight'                                           │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────╯
RuntimeError: weight lm_head.weight does not exist rank=0
2025-01-16T12:13:57.287059Z ERROR text_generation_launcher: Shard 0 failed to start
2025-01-16T12:13:57.287081Z  INFO text_generation_launcher: Shutting down shards

see https://huggingface.co/meta-llama/Llama-3.2-1B/blob/main/config.json#L30
 "tie_word_embeddings": true,


@OlivierDehaene OR @Narsil

 -->
