### PR TITLE
Fix tool call response to adhere to OpenAI spec

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -727,7 +727,7 @@ pub(crate) struct ChatCompletionChoice {
 pub struct ToolCallDelta {
     #[schema(example = "assistant")]
     role: String,
-    tool_calls: DeltaToolCall,
+    tool_calls: Vec<DeltaToolCall>, // Changed to Vec<DeltaToolCall>
 }
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
@@ -770,15 +770,15 @@ impl ChatCompletionChunk {
             }),
             (None, Some(tool_calls)) => ChatCompletionDelta::Tool(ToolCallDelta {
                 role: "assistant".to_string(),
-                tool_calls: DeltaToolCall {
-                    index: 0,
+                tool_calls: tool_calls.iter().enumerate().map(|(index, tool_call)| DeltaToolCall {
+                    index: index as u32,
                     id: String::new(),
                     r#type: "function".to_string(),
                     function: Function {
                         name: None,
-                        arguments: tool_calls[0].to_string(),
+                        arguments: tool_call.to_string(),
                     },
-                },
+                }).collect(),
             }),
             (None, None) => ChatCompletionDelta::Chat(TextMessage {
                 role: "assistant".to_string(),

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1371,7 +1371,7 @@ pub(crate) async fn chat_completions(
                                 system_fingerprint.clone(),
                                 model_id.clone(),
                             );
-
+    
                             yield Ok::<Event, Infallible>(event);
                         }
                     }
@@ -1432,13 +1432,21 @@ pub(crate) async fn chat_completions(
                     (None, Some(content_message))
                 }
                 _ => {
+                    let arguments_string = serde_json::to_string(&arguments).map_err(|e| {
+                        InferError::ToolError(format!(
+                            "Failed to serialize arguments to string: {}",
+                            e
+                        ))
+                    })?;
+                    println!("Arguments: {:?}", arguments);
+                    println!("Arguments String: {:?}", arguments_string);
                     let tool_calls = vec![ToolCall {
-                        id: "0".to_string(),
+                        id: format!("{:09}", 0),
                         r#type: "function".to_string(),
                         function: FunctionDefinition {
                             description: None,
                             name,
-                            arguments,
+                            arguments: Value::String(arguments_string), // Serialize to string here
                         },
                     }];
                     (Some(tool_calls), None)


### PR DESCRIPTION
# What does this PR do?

1. [OpenAI tool call arguments](https://arc.net/l/quote/gqmavaml) field is supposed to be string. TGI seems to output a JSON. Fix it.
2. [ToolCalls](https://arc.net/l/quote/otijcfye) in streaming case should be a list of tool calls, TGI outputs singular tool call. So update the struct accordingly. 
