### PR TITLE
push layer compressed with zstd instead of gzip

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -209,7 +209,7 @@ jobs:
           target: ${{ env.TARGET }}
           tags: ${{ steps.meta.outputs.tags || steps.meta-pr.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels || steps.meta-pr.outputs.labels }}
-          outputs: type=image,compression=gzip,push=true
+          outputs: type=image,compression=zstd,push=true
           # outputs: type=image,compression=gzip,force-compression=true,oci-mediatypes=true,push=true
           cache-from: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=max,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
           cache-to: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=min,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -208,9 +208,15 @@ jobs:
           target: ${{ env.TARGET }}
           tags: ${{ steps.meta.outputs.tags || steps.meta-pr.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels || steps.meta-pr.outputs.labels }}
-          outputs: type=image,compression=zstd,force-compression=true,push=true
           cache-from: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=max,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
           cache-to: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=min,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
+      - name: Build and push Docker image (Zstd)
+        id: build-and-push (zstd)
+        run: |
+          export LAB="sha-${{ env.GITHUB_SHA_SHORT }}${{ env.LABEL }}"
+          docker image tag  docker.io/huggingface/text-generation-inference-ci:$LAB registry.internal.huggingface.tech/api-inference/community/text-generation-inference:$LAB
+
+          docker push registry.internal.huggingface.tech/api-inference/community/text-generation-inference:$LAB ---output "type=image,compression=zstd,force-compression=true,push=true"
       - name: Final
         id: final
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,6 +196,7 @@ jobs:
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
+          # push: true
           platforms: "linux/amd64"
           build-args: |
             GIT_SHA=${{ env.GITHUB_SHA }}
@@ -208,6 +209,8 @@ jobs:
           target: ${{ env.TARGET }}
           tags: ${{ steps.meta.outputs.tags || steps.meta-pr.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels || steps.meta-pr.outputs.labels }}
+          outputs: type=image,compression=gzip,push=true
+          # outputs: type=image,compression=gzip,force-compression=true,oci-mediatypes=true,push=true
           cache-from: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=max,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
           cache-to: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=min,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
       - name: Final

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,7 +165,6 @@ jobs:
           registry: db4c2190dd824d1f950f5d1555fbadf0.azurecr.io
       # If pull request
       - name: Extract metadata (tags, labels) for Docker
-        if: ${{ github.event_name == 'pull_request' }}
         id: meta-pr
         uses: docker/metadata-action@v5
         with:
@@ -182,6 +181,7 @@ jobs:
           flavor: |
             latest=false
           images: |
+            docker.io/huggingface/text-generation-inference-ci
             registry.internal.huggingface.tech/api-inference/community/text-generation-inference
             ghcr.io/huggingface/text-generation-inference
             db4c2190dd824d1f950f5d1555fbadf0.azurecr.io/text-generation-inference

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,7 +196,6 @@ jobs:
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
-          # push: true
           platforms: "linux/amd64"
           build-args: |
             GIT_SHA=${{ env.GITHUB_SHA }}
@@ -209,8 +208,7 @@ jobs:
           target: ${{ env.TARGET }}
           tags: ${{ steps.meta.outputs.tags || steps.meta-pr.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels || steps.meta-pr.outputs.labels }}
-          outputs: type=image,compression=zstd,push=true
-          # outputs: type=image,compression=gzip,force-compression=true,oci-mediatypes=true,push=true
+          outputs: type=image,compression=zstd,force-compression=true,push=true
           cache-from: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=max,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
           cache-to: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=min,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
       - name: Final

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -262,14 +262,13 @@ jobs:
       cancel-in-progress: true
     runs-on:
       group: aws-g6-12xl-plus-priv-cache
-    container:
-      image: ${{ needs.build-and-push.outputs.docker_image }}
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      options: --gpus all --shm-size=8g
-
     steps:
+      - name: Initialize Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          buildkitd-config: /tmp/buildkitd.toml
       - name: Run C++/CUDA tests
         if: ${{ env.LABEL == 'ci-runtime' }}
-        run: /usr/local/tgi/bin/tgi_trtllm_backend_tests
+        run: docker run  --gpus all --shm-size=8g --entrypoint /usr/local/tgi/bin/tgi_trtllm_backend_tests ${{ needs.build-and-push.outputs.docker_image }}
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -250,6 +250,7 @@ jobs:
           export EXTRA_PYTEST="${{ needs.build-and-push.outputs.extra_pytest }}"
           export HF_TOKEN=${{ secrets.HF_TOKEN }}
           echo $DOCKER_IMAGE
+          docker buildx install
           docker pull $DOCKER_IMAGE
           pytest -s -vv integration-tests ${PYTEST_FLAGS} ${EXTRA_PYTEST}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,7 +196,7 @@ jobs:
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
-          platforms: 'linux/amd64'
+          platforms: "linux/amd64"
           build-args: |
             GIT_SHA=${{ env.GITHUB_SHA }}
             DOCKER_LABEL=sha-${{ env.GITHUB_SHA_SHORT }}${{ env.LABEL }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,6 +214,7 @@ jobs:
         id: build-and-push-zstd
         run: |
           export LAB="sha-${{ env.GITHUB_SHA_SHORT }}${{ env.LABEL }}"
+          docker pull docker.io/huggingface/text-generation-inference-ci:$LAB
           docker image tag  docker.io/huggingface/text-generation-inference-ci:$LAB registry.internal.huggingface.tech/api-inference/community/text-generation-inference:$LAB
 
           docker push registry.internal.huggingface.tech/api-inference/community/text-generation-inference:$LAB ---output "type=image,compression=zstd,force-compression=true,push=true"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,7 +196,6 @@ jobs:
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
-          push: true
           platforms: 'linux/amd64'
           build-args: |
             GIT_SHA=${{ env.GITHUB_SHA }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -211,7 +211,7 @@ jobs:
           cache-from: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=max,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
           cache-to: type=s3,region=us-east-1,bucket=ci-docker-buildx-cache,name=text-generation-inference-cache${{ env.LABEL }},mode=min,access_key_id=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_ACCESS_KEY_ID }},secret_access_key=${{ secrets.S3_CI_DOCKER_BUILDX_CACHE_SECRET_ACCESS_KEY }},mode=min
       - name: Build and push Docker image (Zstd)
-        id: build-and-push (zstd)
+        id: build-and-push-zstd
         run: |
           export LAB="sha-${{ env.GITHUB_SHA_SHORT }}${{ env.LABEL }}"
           docker image tag  docker.io/huggingface/text-generation-inference-ci:$LAB registry.internal.huggingface.tech/api-inference/community/text-generation-inference:$LAB

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -576,6 +576,7 @@ async def launcher(error_log):
             ]
 
         client.api.timeout = 1000
+        subprocess.check_call(["docker", "pull", DOCKER_IMAGE])
         container = client.containers.run(
             DOCKER_IMAGE,
             command=args,


### PR DESCRIPTION
Image is smaller but most importantly way faster to decompress.
`force-compression` is used to re-compress all cached layers which are in gzip.

Pull duration tests :
  L4 g6.2xlarge (base) in 1m53.837s (1m53.837s including waiting). Image size: 5650343354 bytes.
  L4 g6.2xlarge (zsd ) in 1m25.92s (1m25.92s including waiting). Image size: 4581485004 bytes.