### PR TITLE
Triton fix

### DIFF
--- a/Dockerfile_intel
+++ b/Dockerfile_intel
@@ -190,7 +190,7 @@ RUN pip install https://download.pytorch.org/whl/nightly/cpu/torch-2.5.0.dev2024
 RUN pip install https://download.pytorch.org/whl/nightly/cpu/torchvision-0.20.0.dev20240815%2Bcpu-cp311-cp311-linux_x86_64.whl
 RUN pip install https://download.pytorch.org/whl/nightly/cpu/torchaudio-2.4.0.dev20240815%2Bcpu-cp311-cp311-linux_x86_64.whl
 
-RUN pip install triton py-libnuma
+RUN pip install triton==3.1.0 py-libnuma
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
the latest 3.2.0 version will make ipex import fail.
 File "/opt/conda/lib/python3.11/site-packages/intel_extension_for_pytorch/llm/frontend.py", line 1, in <module>
    from intel_extension_for_pytorch.transformers.optimize import optimize
  File "/opt/conda/lib/python3.11/site-packages/intel_extension_for_pytorch/transformers/__init__.py", line 3, in <module>
    from .models.cpu.modules.attentions import _IPEXAttentionCPU
  File "/opt/conda/lib/python3.11/site-packages/intel_extension_for_pytorch/transformers/models/cpu/modules/attentions.py", line 2, in <module>
    from ...cpu.fusions.mha_fusion import (
  File "/opt/conda/lib/python3.11/site-packages/intel_extension_for_pytorch/transformers/models/cpu/fusions/mha_fusion.py", line 592, in <module>
    @torch.compile(dynamic=True, options={"fx_graph_cache": True})
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/__init__.py", line 2425, in fn
    return compile(
           ^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/__init__.py", line 2444, in compile
    backend = _TorchCompileInductorWrapper(mode, options, dynamic)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/__init__.py", line 2181, in __init__
    from torch._inductor.compile_fx import compile_fx
  File "/opt/conda/lib/python3.11/site-packages/torch/_inductor/compile_fx.py", line 48, in <module>
    from torch._inductor.debug import save_args_for_compile_fx_inner
  File "/opt/conda/lib/python3.11/site-packages/torch/_inductor/debug.py", line 26, in <module>
    from . import config, ir  # noqa: F811, this is needed
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/_inductor/ir.py", line 77, in <module>
    from .runtime.hints import ReductionHint
  File "/opt/conda/lib/python3.11/site-packages/torch/_inductor/runtime/hints.py", line 36, in <module>
    attr_desc_fields = {f.name for f in fields(AttrsDescriptor)}
                                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/dataclasses.py", line 1246, in fields
    raise TypeError('must be called with a dataclass type or instance') from None
TypeError: must be called with a dataclass type or instance