### PR TITLE
Add `loop_controls` feature to `minijinja` to handle `{% break %}`

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -48,7 +48,7 @@ ngrok = { version = "0.13.1", features = ["axum"], optional = true }
 init-tracing-opentelemetry = { version = "0.14.1", features = [
   "opentelemetry-otlp",
 ] }
-minijinja = { workspace = true }
+minijinja = { workspace = true, features = ["loop_controls"] }
 minijinja-contrib = { workspace = true }
 futures-util = "0.3.30"
 regex = "1.10.3"


### PR DESCRIPTION
# What does this PR do?

This PR adds the feature `loop_controls` to `minijinja` as per [minijinja - optional features](https://docs.rs/minijinja/2.7.0/minijinja/?search=break#optional-features), as some models as e.g. [`CohereForAI/c4ai-command-r7b-12-2024`](https://huggingface.co/CohereForAI/c4ai-command-r7b-12-2024) make use of the `break` statement within the inner loops in the template, which is not supported on `minijinja` by default.

As of `minijinja`'s description of the `loop_controls` feature "enables the {% break %} and {% continue %} loop control flow tags."

Thanks to @Cyrilvallez for reporting internally!

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@OlivierDehaene OR @Narsil
