### PR TITLE
Add request parameters to OTel span for `/v1/chat/completions` endpoint

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1217,7 +1217,7 @@ example = json ! ({"error": "Incomplete generation"})),
 #[instrument(
 skip_all,
 fields(
-// parameters = ? req.parameters,
+parameters,
 total_time,
 validation_time,
 queue_time,
@@ -1243,7 +1243,7 @@ pub(crate) async fn chat_completions(
     } = chat.clone();
     let (generate_request, using_tools): (GenerateRequest, bool) =
         chat.try_into_generate(&infer)?;
-
+    span.record("parameters", format!("{:?}", generate_request.parameters));
     let logprobs = logprobs.unwrap_or_default();
 
     // extract model id from request if specified


### PR DESCRIPTION
Adds request parameters to OpenTelemetry spans generated by `/v1/chat/completions`. 
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@OlivierDehaene OR @Narsil

