### PR TITLE
change ChatCompletionChunk to align with "OpenAI Chat Completions str…

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -790,12 +790,15 @@ impl ChatCompletionChunk {
             created,
             model,
             system_fingerprint,
-            choices: vec![ChatCompletionChoice {
-                index: 0,
-                delta,
-                logprobs,
-                finish_reason,
-            }],
+            choices: match usage {
+                None => vec![ChatCompletionChoice {
+                    index: 0,
+                    delta,
+                    logprobs,
+                    finish_reason,
+                }],
+                _ => vec![],
+            },
             usage,
         }
     }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1345,6 +1345,18 @@ pub(crate) async fn chat_completions(
                                             model_id.clone(),
                                         );
                                         yield Ok::<Event, Infallible>(event);
+                                        if stream_token.details.is_some() && stream_options
+                                            .as_ref()
+                                            .map(|s| s.include_usage)
+                                            .unwrap_or(false) {
+                                            let usage_event = create_usage_event_from_stream_token(
+                                                stream_token,
+                                                stream_options.clone(),
+                                                system_fingerprint.clone(),
+                                                model_id.clone(),
+                                            );
+                                            yield Ok::<Event, Infallible>(usage_event);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
…eaming API"

When stream_options: {"include_usage": true} is included, choices is None only for the last chunk, and usage is always None except for the last chunk.

see https://cookbook.openai.com/examples/how_to_stream_completions#4-how-to-get-token-usage-data-for-streamed-chat-completion-response
@OlivierDehaene OR @Narsil
