### PR TITLE
Optional content field in Chat Completions Request

### DIFF
--- a/router/src/infer/chat_template.rs
+++ b/router/src/infer/chat_template.rs
@@ -67,7 +67,9 @@ impl ChatTemplate {
                     format!("\n---\n{}", tool_prompt)
                 };
                 if let Some(last_message) = messages.last_mut() {
-                    last_message.content.push(MessageChunk::Text { text });
+                    if let Some(content) = last_message.content.as_mut() {
+                        content.push(MessageChunk::Text { text });
+                    }
                 }
                 Some(tools)
             }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1183,7 +1183,7 @@ pub struct Message {
     #[schema(example = "user")]
     role: String,
     #[schema(example = "My name is David and I")]
-    pub content: MessageContent,
+    pub content: Option<MessageContent>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(example = "\"David\"")]
     name: Option<String>,
@@ -1226,15 +1226,19 @@ impl From<Message> for TextMessage {
         TextMessage {
             role: value.role,
             content: match value.content {
-                MessageContent::SingleText(text) => text,
-                MessageContent::MultipleChunks(chunks) => chunks
-                    .into_iter()
-                    .map(|chunk| match chunk {
-                        MessageChunk::Text { text } => text,
-                        MessageChunk::ImageUrl { image_url } => format!("![]({})", image_url.url),
-                    })
-                    .collect::<Vec<_>>()
-                    .join(""),
+                // If content is Some(MessageContent), handle it accordingly
+                Some(MessageContent::SingleText(text)) => text,
+                Some(MessageContent::MultipleChunks(chunks)) => {
+                    chunks.into_iter()
+                        .map(|chunk| match chunk {
+                            MessageChunk::Text { text } => text,
+                            MessageChunk::ImageUrl { image_url } => format!("![]({})", image_url.url),
+                        })
+                        .collect::<Vec<_>>()
+                        .join("")
+                }
+                // If content is None, use an empty string or a default message
+                None => String::new(), // or you could use "No content" or another placeholder
             },
         }
     }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1187,6 +1187,7 @@ pub struct Message {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(example = "\"David\"")]
     name: Option<String>,
+    tool_calls: Option<Vec<ToolCall>>,
 }
 
 #[derive(Clone, Deserialize, Serialize, ToSchema, Debug, PartialEq)]


### PR DESCRIPTION
Currently, TGI is validating that "content" field always exists in chat completions request. But in case of an "assistant" message type in OpenAI [messages](https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages) struct, content can be empty.

According to OpenAI spec: "The contents of the assistant message. Required unless tool_calls or function_call is specified."

Example:
```
{
    "model": "llama-3-1-8b",
    "stream": false,
    "messages": [
        {
            "role": "assistant",
            "tool_calls": [
                {
                    "id": "0",
                    "function": {
                        "arguments": "{\"location\":\"Boston\",\"unit\":\"celsius\"}",
                        "name": "get_current_weather"
                    },
                    "type": "function"
                }
            ]
        }
    ]
}
```
Error returned by TGI:
```
Failed to deserialize the JSON body into the target type: messages[0]: missing field `content` at line 17 column 9
```

This PR fixes that by making content field optional and adding `tool_calls` to the `Message` struct (used in ChatRequest)