### PR TITLE
feat: Add the parsing of HF_HUB_USER_AGENT_ORIGIN environment variable for telemetry

### DIFF
--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -17,4 +17,5 @@ jobs:
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@main
         with:
-          extra_args: --results=verified,unknown
+          # exclude buggy postgres detector that is causing false positives and not relevant to our codebase
+          extra_args: --results=verified,unknown --exclude-detectors=postgres

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1877,6 +1877,8 @@ pub async fn run(
 
     // Only send usage stats when TGI is run in container and the function returns Some
     let is_container = matches!(usage_stats::is_container(), Ok(true));
+    // retrieve the huggingface_hub user agent origin if set, and add the origin to telemetry
+    let origin = std::env::var("HF_HUB_USER_AGENT_ORIGIN").ok();
     let user_agent = match (usage_stats_level, is_container) {
         (usage_stats::UsageStatsLevel::On | usage_stats::UsageStatsLevel::NoStack, true) => {
             let reduced_args = usage_stats::Args::new(
@@ -1899,6 +1901,7 @@ pub async fn run(
                 max_client_batch_size,
                 usage_stats_level,
                 backend.name(),
+                origin,
             );
             Some(usage_stats::UserAgent::new(reduced_args))
         }

--- a/router/src/usage_stats.rs
+++ b/router/src/usage_stats.rs
@@ -98,6 +98,7 @@ pub struct Args {
     max_client_batch_size: usize,
     usage_stats_level: UsageStatsLevel,
     backend_name: &'static str,
+    origin: Option<String>,
 }
 
 impl Args {
@@ -122,6 +123,7 @@ impl Args {
         max_client_batch_size: usize,
         usage_stats_level: UsageStatsLevel,
         backend_name: &'static str,
+        origin: Option<String>,
     ) -> Self {
         Self {
             model_config,
@@ -143,6 +145,7 @@ impl Args {
             max_client_batch_size,
             usage_stats_level,
             backend_name,
+            origin,
         }
     }
 }


### PR DESCRIPTION
Add the parsing of HF_HUB_USER_AGENT_ORIGIN environment variable for telemetry to add info about the environment running TGI. That is useful to track usage in case of collaborations for example.

Synced with https://github.com/huggingface/huggingface_hub/pull/2869