### PR TITLE
Add modules_to_not_convert in quantized model

### DIFF
--- a/server/text_generation_server/layers/gptq/__init__.py
+++ b/server/text_generation_server/layers/gptq/__init__.py
@@ -6,7 +6,12 @@ import torch
 from loguru import logger
 from text_generation_server.utils.import_utils import SYSTEM
 from text_generation_server.utils.log import log_once
-from text_generation_server.utils.weights import Weight, Weights, WeightsLoader, UnquantizedWeight
+from text_generation_server.utils.weights import (
+    Weight,
+    Weights,
+    WeightsLoader,
+    UnquantizedWeight,
+)
 
 if SYSTEM == "ipex":
     from .ipex import QuantLinear
@@ -181,7 +186,9 @@ class GPTQWeightsLoader(WeightsLoader):
             use_exllama=use_exllama,
         )
 
-    def is_layer_skipped_quantization(self, prefix: str, modules_to_not_convert: List[str]):
+    def is_layer_skipped_quantization(
+        self, prefix: str, modules_to_not_convert: List[str]
+    ):
         if modules_to_not_convert is None:
             return False
         return any(module_name in prefix for module_name in modules_to_not_convert)

--- a/server/text_generation_server/layers/moe/unquantized.py
+++ b/server/text_generation_server/layers/moe/unquantized.py
@@ -85,6 +85,8 @@ class UnquantizedSparseMoELayer(nn.Module):
                 use_grouped_topk=self.n_expert_group is not None,
                 num_expert_group=self.n_expert_group,
                 topk_group=self.topk_group,
+                scoring_func=self.scoring_func,
+                e_score_correction_bias=self.e_score_correction_bias,
             )
         return fused_moe(
             x,

--- a/server/text_generation_server/layers/moe/unquantized.py
+++ b/server/text_generation_server/layers/moe/unquantized.py
@@ -85,8 +85,6 @@ class UnquantizedSparseMoELayer(nn.Module):
                 use_grouped_topk=self.n_expert_group is not None,
                 num_expert_group=self.n_expert_group,
                 topk_group=self.topk_group,
-                scoring_func=self.scoring_func,
-                e_score_correction_bias=self.e_score_correction_bias,
             )
         return fused_moe(
             x,

--- a/server/text_generation_server/utils/quantization.py
+++ b/server/text_generation_server/utils/quantization.py
@@ -76,7 +76,9 @@ def _get_quantizer_config(model_id, revision):
         quant_method = data["quantization_config"]["quant_method"]
         checkpoint_format = data["quantization_config"].get("checkpoint_format")
         desc_act = data["quantization_config"].get("desc_act", False)
-        modules_to_not_convert = data["quantization_config"].get("modules_to_not_convert", None)
+        modules_to_not_convert = data["quantization_config"].get(
+            "modules_to_not_convert", None
+        )
     except Exception:
         filename = "quantize_config.json"
         try:

--- a/server/text_generation_server/utils/quantization.py
+++ b/server/text_generation_server/utils/quantization.py
@@ -21,6 +21,7 @@ class _QuantizerConfig:
     quant_method: str
     sym: bool
     weight_block_size: Optional[List[int]]
+    modules_to_not_convert: Optional[List[str]]
 
 
 @dataclass
@@ -51,6 +52,7 @@ def _get_quantizer_config(model_id, revision):
     sym = False
     desc_act = False
     weight_block_size = None
+    modules_to_not_convert = None
 
     filename = "config.json"
     try:
@@ -73,7 +75,8 @@ def _get_quantizer_config(model_id, revision):
         # Order is important here, desc_act is missing on some real models
         quant_method = data["quantization_config"]["quant_method"]
         checkpoint_format = data["quantization_config"].get("checkpoint_format")
-        desc_act = data["quantization_config"]["desc_act"]
+        desc_act = data["quantization_config"].get("desc_act", False)
+        modules_to_not_convert = data["quantization_config"].get("modules_to_not_convert", None)
     except Exception:
         filename = "quantize_config.json"
         try:
@@ -110,6 +113,7 @@ def _get_quantizer_config(model_id, revision):
         sym=sym,
         desc_act=desc_act,
         weight_block_size=weight_block_size,
+        modules_to_not_convert=modules_to_not_convert,
     )
 
 
@@ -159,6 +163,7 @@ def get_loader(
                 quant_method=quantizer_config.quant_method,
                 quantize=quantize,
                 sym=quantizer_config.sym,
+                modules_to_not_convert=quantizer_config.modules_to_not_convert,
             )
     elif quantize == "bitsandbytes":
         from text_generation_server.layers.bnb import BNBWeight

--- a/server/text_generation_server/utils/quantization.py
+++ b/server/text_generation_server/utils/quantization.py
@@ -77,7 +77,7 @@ def _get_quantizer_config(model_id, revision):
         checkpoint_format = data["quantization_config"].get("checkpoint_format")
         desc_act = data["quantization_config"].get("desc_act", False)
         modules_to_not_convert = data["quantization_config"].get(
-            "modules_to_not_convert", None
+            "modules_to_not_convert", []
         )
     except Exception:
         filename = "quantize_config.json"


### PR DESCRIPTION
Fix modules_to_not_convert to skip the unquantized linear. As some models have unquantized modules, we should skip these modules in quantization.

This PR could enable [qwen2_vl-awq](https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct-AWQ) model.
Without this change, the error will be:
```
Traceback (most recent call last):
  File "/opt/conda/bin/text-generation-server", line 10, in <module>
    sys.exit(app())
  File "/opt/conda/lib/python3.11/site-packages/typer/main.py", line 323, in __call__
    return get_command(self)(*args, **kwargs)
  File "/opt/conda/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/lib/python3.11/site-packages/typer/core.py", line 743, in main
    return _main(
  File "/opt/conda/lib/python3.11/site-packages/typer/core.py", line 198, in _main
    rv = self.invoke(ctx)
  File "/opt/conda/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/conda/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/opt/conda/lib/python3.11/site-packages/typer/main.py", line 698, in wrapper
    return callback(**use_params)
  File "/usr/src/server/text_generation_server/cli.py", line 119, in serve
    server.serve(
  File "/usr/src/server/text_generation_server/server.py", line 316, in serve
    asyncio.run(
  File "/opt/conda/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
  File "/opt/conda/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/opt/conda/lib/python3.11/asyncio/base_events.py", line 641, in run_until_complete
    self.run_forever()
  File "/opt/conda/lib/python3.11/asyncio/base_events.py", line 608, in run_forever
    self._run_once()
  File "/opt/conda/lib/python3.11/asyncio/base_events.py", line 1936, in _run_once
    handle._run()
  File "/opt/conda/lib/python3.11/asyncio/events.py", line 84, in _run
    self._context.run(self._callback, *self._args)
> File "/usr/src/server/text_generation_server/server.py", line 268, in serve_inner
    model = get_model_with_lora_adapters(
  File "/usr/src/server/text_generation_server/models/__init__.py", line 1592, in get_model_with_lora_adapters
    model = get_model(
  File "/usr/src/server/text_generation_server/models/__init__.py", line 1388, in get_model
    return VlmCausalLM(
  File "/usr/src/server/text_generation_server/models/vlm_causal_lm.py", line 354, in __init__
    super().__init__(
  File "/usr/src/server/text_generation_server/models/flash_causal_lm.py", line 1289, in __init__
    weights_loader = get_loader(quantize, model_id, revision)
  File "/usr/src/server/text_generation_server/utils/quantization.py", line 159, in get_loader
    return GPTQWeightsLoader(
TypeError: GPTQWeightsLoader.__init__() got an unexpected keyword argument 'modules_to_not_convert'
2025-02-25T13:01:44.894419Z ERROR shard-manager: text_generation_launcher: Shard complete standard error output:
```