### PR TITLE
Added model name label to metrics and added an optional argument --served-model-name

### DIFF
--- a/backends/llamacpp/src/main.rs
+++ b/backends/llamacpp/src/main.rs
@@ -19,6 +19,10 @@ struct Args {
     #[clap(long, env)]
     model_id: String,
 
+    /// Name under which the model is served. Defaults to `model_id` if not provided.
+    #[clap(long, env)]
+    served_model_name: Option<String>,
+
     /// Revision of the model.
     #[clap(default_value = "main", long, env)]
     revision: String,
@@ -152,6 +156,10 @@ struct Args {
 async fn main() -> Result<(), RouterError> {
     let args = Args::parse();
 
+    let served_model_name = args.served_model_name
+        .clone()
+        .unwrap_or_else(|| args.model_id.clone());
+
     logging::init_logging(args.otlp_endpoint, args.otlp_service_name, args.json_output);
 
     let n_threads = match args.n_threads {
@@ -264,6 +272,7 @@ async fn main() -> Result<(), RouterError> {
         args.max_client_batch_size,
         args.usage_stats,
         args.payload_limit,
+        served_model_name
     )
     .await?;
     Ok(())

--- a/backends/trtllm/src/main.rs
+++ b/backends/trtllm/src/main.rs
@@ -45,6 +45,8 @@ struct Args {
     revision: Option<String>,
     #[clap(long, env)]
     model_id: String,
+    #[clap(long, env)]
+    served_model_name: Option<String>,
     #[clap(default_value = "2", long, env)]
     validation_workers: usize,
     #[clap(long, env)]
@@ -227,6 +229,7 @@ async fn main() -> Result<(), TensorRtLlmBackendError> {
         tokenizer_config_path,
         revision,
         model_id,
+        served_model_name,
         validation_workers,
         json_output,
         otlp_endpoint,
@@ -238,6 +241,10 @@ async fn main() -> Result<(), TensorRtLlmBackendError> {
         usage_stats,
         payload_limit,
     } = args;
+
+    let served_model_name = args.served_model_name
+        .clone()
+        .unwrap_or_else(|| args.model_id.clone());
 
     // Launch Tokio runtime
     text_generation_router::logging::init_logging(otlp_endpoint, otlp_service_name, json_output);
@@ -318,6 +325,7 @@ async fn main() -> Result<(), TensorRtLlmBackendError> {
                 max_client_batch_size,
                 usage_stats,
                 payload_limit,
+                served_model_name,
             )
             .await?;
             Ok(())

--- a/backends/v2/src/lib.rs
+++ b/backends/v2/src/lib.rs
@@ -39,6 +39,7 @@ pub async fn connect_backend(
     max_batch_total_tokens: Option<u32>,
     max_waiting_tokens: usize,
     max_batch_size: Option<usize>,
+    served_model_name: String,
 ) -> Result<(BackendV2, BackendInfo), V2Error> {
     // Helper function
     let check_max_batch_total_tokens = |max_supported_batch_total_tokens: Option<u32>| {
@@ -108,7 +109,7 @@ pub async fn connect_backend(
         model_dtype: shard_info.dtype.clone(),
         speculate: shard_info.speculate as usize,
     };
-
+        
     let backend = BackendV2::new(
         sharded_client,
         waiting_served_ratio,
@@ -119,6 +120,7 @@ pub async fn connect_backend(
         shard_info.requires_padding,
         shard_info.window_size,
         shard_info.speculate,
+        served_model_name,
     );
 
     tracing::info!("Using backend V3");

--- a/backends/v2/src/main.rs
+++ b/backends/v2/src/main.rs
@@ -7,6 +7,9 @@ use thiserror::Error;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
+    #[clap(long, env)]
+    served_model_name: String,
+
     #[command(subcommand)]
     command: Option<Commands>,
 
@@ -83,8 +86,11 @@ enum Commands {
 async fn main() -> Result<(), RouterError> {
     // Get args
     let args = Args::parse();
+    let _served_model_name = args.served_model_name.clone();
+
     // Pattern match configuration
     let Args {
+        served_model_name,
         command,
         max_concurrent_requests,
         max_best_of,
@@ -170,8 +176,9 @@ async fn main() -> Result<(), RouterError> {
         max_batch_total_tokens,
         max_waiting_tokens,
         max_batch_size,
+        served_model_name.clone(),
     )
-    .await?;
+    .await?;   
 
     // Run server
     server::run(
@@ -198,6 +205,7 @@ async fn main() -> Result<(), RouterError> {
         max_client_batch_size,
         usage_stats,
         payload_limit,
+        served_model_name.clone(),
     )
     .await?;
     Ok(())

--- a/backends/v3/src/lib.rs
+++ b/backends/v3/src/lib.rs
@@ -54,6 +54,7 @@ pub async fn connect_backend(
     max_batch_total_tokens: Option<u32>,
     max_waiting_tokens: usize,
     max_batch_size: Option<usize>,
+    served_model_name: String,
 ) -> Result<(BackendV3, BackendInfo), V3Error> {
     // Helper function
     let check_max_batch_total_tokens = |(
@@ -161,6 +162,7 @@ pub async fn connect_backend(
         max_waiting_tokens,
         max_batch_size,
         shard_info,
+        served_model_name,
     );
 
     tracing::info!("Using backend V3");

--- a/backends/v3/src/main.rs
+++ b/backends/v3/src/main.rs
@@ -7,6 +7,9 @@ use thiserror::Error;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
+    #[clap(long, env)]
+    served_model_name: String,
+
     #[command(subcommand)]
     command: Option<Commands>,
 
@@ -74,6 +77,7 @@ struct Args {
     payload_limit: usize,
 }
 
+
 #[derive(Debug, Subcommand)]
 enum Commands {
     PrintSchema,
@@ -83,8 +87,11 @@ enum Commands {
 async fn main() -> Result<(), RouterError> {
     // Get args
     let args = Args::parse();
+    let _served_model_name = args.served_model_name.clone();
+
     // Pattern match configuration
     let Args {
+        served_model_name,
         command,
         max_concurrent_requests,
         max_best_of,
@@ -151,6 +158,7 @@ async fn main() -> Result<(), RouterError> {
         max_batch_total_tokens,
         max_waiting_tokens,
         max_batch_size,
+        served_model_name.clone(),
     )
     .await?;
 
@@ -214,6 +222,7 @@ async fn main() -> Result<(), RouterError> {
         max_client_batch_size,
         usage_stats,
         payload_limit,
+        served_model_name.clone(),
     )
     .await?;
     Ok(())

--- a/backends/v3/src/queue.rs
+++ b/backends/v3/src/queue.rs
@@ -51,6 +51,7 @@ impl Queue {
         speculate: u32,
         max_batch_total_tokens: u32,
         support_chunking: bool,
+        served_model_name: String,
     ) -> Self {
         // Create channel
         let (queue_sender, queue_receiver) = mpsc::unbounded_channel();
@@ -65,6 +66,7 @@ impl Queue {
             max_batch_total_tokens,
             support_chunking,
             queue_receiver,
+            served_model_name,
         ));
 
         Self { queue_sender }
@@ -124,6 +126,7 @@ async fn queue_task(
     max_batch_total_tokens: u32,
     support_chunking: bool,
     mut receiver: mpsc::UnboundedReceiver<QueueCommand>,
+    served_model_name: String,
 ) {
     let mut state = State::new(
         requires_padding,
@@ -139,7 +142,7 @@ async fn queue_task(
         match cmd {
             QueueCommand::Append(entry, span) => {
                 span.in_scope(|| state.append(*entry));
-                metrics::gauge!("tgi_queue_size").increment(1.0);
+                metrics::gauge!("tgi_queue_size", "model_name" => served_model_name.clone()).increment(1.0);
             }
             QueueCommand::NextBatch {
                 min_size,
@@ -150,11 +153,11 @@ async fn queue_task(
                 span,
             } => {
                 let next_batch = state
-                    .next_batch(min_size, max_size, prefill_token_budget, token_budget)
+                    .next_batch(min_size, max_size, prefill_token_budget, token_budget, served_model_name.clone())
                     .instrument(span)
                     .await;
                 response_sender.send(next_batch).unwrap();
-                metrics::gauge!("tgi_queue_size").set(state.entries.len() as f64);
+                metrics::gauge!("tgi_queue_size", "model_name" => served_model_name.clone()).set(state.entries.len() as f64);
             }
         }
     }
@@ -235,6 +238,7 @@ impl State {
         max_size: Option<usize>,
         prefill_token_budget: u32,
         token_budget: u32,
+        served_model_name: String,
     ) -> Option<NextBatch> {
         if self.entries.is_empty() {
             tracing::debug!("No queue");
@@ -274,7 +278,7 @@ impl State {
             // Filter entries where the response receiver was dropped (== entries where the request
             // was dropped by the client)
             if entry.response_tx.is_closed() {
-                metrics::counter!("tgi_request_failure", "err" => "dropped").increment(1);
+                metrics::counter!("tgi_request_failure", "err" => "dropped", "model_name" => served_model_name.clone()).increment(1);
                 tracing::debug!("Dropping entry");
                 continue;
             }
@@ -478,7 +482,7 @@ impl State {
         // Increment batch id
         self.next_batch_id += 1;
 
-        metrics::histogram!("tgi_batch_next_size").record(batch.size as f64);
+        metrics::histogram!("tgi_batch_next_size", "model_name" => served_model_name.clone()).record(batch.size as f64);
 
         Some((batch_entries, batch, next_batch_span))
     }
@@ -606,21 +610,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_next_batch_empty() {
+        let served_model_name = "bigscience/blomm-560m".to_string();
         let mut state = State::new(false, 1, false, None, 0, 16, false);
 
-        assert!(state.next_batch(None, None, 1, 1).await.is_none());
-        assert!(state.next_batch(Some(1), None, 1, 1).await.is_none());
+        assert!(state.next_batch(None, None, 1, 1, served_model_name.clone()).await.is_none());
+        assert!(state.next_batch(Some(1), None, 1, 1, served_model_name.clone()).await.is_none());
     }
 
     #[tokio::test]
     async fn test_next_batch_min_size() {
+        let served_model_name = "bigscience/blomm-560m".to_string();
+
         let mut state = State::new(false, 1, false, None, 0, 16, false);
         let (entry1, _guard1) = default_entry();
         let (entry2, _guard2) = default_entry();
         state.append(entry1);
         state.append(entry2);
 
-        let (entries, batch, _) = state.next_batch(None, None, 2, 2).await.unwrap();
+        let (entries, batch, _) = state.next_batch(None, None, 2, 2, served_model_name.clone()).await.unwrap();
         assert_eq!(entries.len(), 2);
         assert!(entries.contains_key(&0));
         assert!(entries.contains_key(&1));
@@ -636,7 +643,7 @@ mod tests {
         let (entry3, _guard3) = default_entry();
         state.append(entry3);
 
-        assert!(state.next_batch(Some(2), None, 2, 2).await.is_none());
+        assert!(state.next_batch(Some(2), None, 2, 2, served_model_name.clone()).await.is_none());
 
         assert_eq!(state.next_id, 3);
         assert_eq!(state.entries.len(), 1);
@@ -646,13 +653,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_next_batch_max_size() {
+        let served_model_name = "bigscience/blomm-560m".to_string();
         let mut state = State::new(false, 1, false, None, 0, 16, false);
         let (entry1, _guard1) = default_entry();
         let (entry2, _guard2) = default_entry();
         state.append(entry1);
         state.append(entry2);
 
-        let (entries, batch, _) = state.next_batch(None, Some(1), 2, 2).await.unwrap();
+        let (entries, batch, _) = state.next_batch(None, Some(1), 2, 2, served_model_name.clone()).await.unwrap();
         assert_eq!(entries.len(), 1);
         assert!(entries.contains_key(&0));
         assert!(entries.get(&0).unwrap().batch_time.is_some());
@@ -666,13 +674,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_next_batch_token_budget() {
+        let served_model_name = "bigscience/blomm-560m".to_string();
         let mut state = State::new(false, 1, false, None, 0, 16, false);
         let (entry1, _guard1) = default_entry();
         let (entry2, _guard2) = default_entry();
         state.append(entry1);
         state.append(entry2);
 
-        let (entries, batch, _) = state.next_batch(None, None, 1, 1).await.unwrap();
+        let (entries, batch, _) = state.next_batch(None, None, 1, 1, served_model_name.clone()).await.unwrap();
         assert_eq!(entries.len(), 1);
         assert!(entries.contains_key(&0));
         assert_eq!(batch.id, 0);
@@ -685,7 +694,7 @@ mod tests {
         let (entry3, _guard3) = default_entry();
         state.append(entry3);
 
-        let (entries, batch, _) = state.next_batch(None, None, 3, 3).await.unwrap();
+        let (entries, batch, _) = state.next_batch(None, None, 3, 3, served_model_name.clone()).await.unwrap();
         assert_eq!(entries.len(), 2);
         assert!(entries.contains_key(&1));
         assert!(entries.contains_key(&2));
@@ -699,14 +708,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_queue_append() {
-        let queue = Queue::new(false, 1, false, None, 0, 16, false);
+        let served_model_name = "bigscience/blomm-560m".to_string();
+        let queue = Queue::new(false, 1, false, None, 0, 16, false, served_model_name.clone());
         let (entry, _guard) = default_entry();
         queue.append(entry);
     }
 
     #[tokio::test]
     async fn test_queue_next_batch_empty() {
-        let queue = Queue::new(false, 1, false, None, 0, 16, false);
+        let served_model_name = "bigscience/blomm-560m".to_string();
+        let queue = Queue::new(false, 1, false, None, 0, 16, false, served_model_name.clone());
 
         assert!(queue.next_batch(None, None, 1, 1).await.is_none());
         assert!(queue.next_batch(Some(1), None, 1, 1).await.is_none());
@@ -714,7 +725,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_queue_next_batch_min_size() {
-        let queue = Queue::new(false, 1, false, None, 0, 16, false);
+        let served_model_name = "bigscience/blomm-560m".to_string();
+        let queue = Queue::new(false, 1, false, None, 0, 16, false, served_model_name.clone());
         let (entry1, _guard1) = default_entry();
         let (entry2, _guard2) = default_entry();
         queue.append(entry1);
@@ -747,7 +759,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_queue_next_batch_max_size() {
-        let queue = Queue::new(false, 1, false, None, 0, 16, false);
+        let served_model_name = "bigscience/blomm-560m".to_string();
+        let queue = Queue::new(false, 1, false, None, 0, 16, false, served_model_name.clone());
         let (entry1, _guard1) = default_entry();
         let (entry2, _guard2) = default_entry();
         queue.append(entry1);
@@ -763,7 +776,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_queue_next_batch_token_budget() {
-        let queue = Queue::new(false, 1, false, None, 0, 16, false);
+        let served_model_name = "bigscience/blomm-560m".to_string();
+        let queue = Queue::new(false, 1, false, None, 0, 16, false, served_model_name.clone());
         let (entry1, _guard1) = default_entry();
         let (entry2, _guard2) = default_entry();
         queue.append(entry1);
@@ -788,7 +802,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_queue_next_batch_token_speculate() {
-        let queue = Queue::new(true, 1, false, None, 2, 16, false);
+        let served_model_name = "bigscience/blomm-560m".to_string();
+        let queue = Queue::new(true, 1, false, None, 2, 16, false, served_model_name.clone());
         let (entry1, _guard1) = default_entry();
         let (entry2, _guard2) = default_entry();
         queue.append(entry1);
@@ -807,7 +822,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_queue_next_batch_dropped_receiver() {
-        let queue = Queue::new(false, 1, false, None, 0, 16, false);
+        let served_model_name = "bigscience/blomm-560m".to_string();
+        let queue = Queue::new(false, 1, false, None, 0, 16, false, served_model_name.clone());
         let (entry, _) = default_entry();
         queue.append(entry);
 

--- a/router/src/sagemaker.rs
+++ b/router/src/sagemaker.rs
@@ -68,15 +68,16 @@ pub(crate) async fn sagemaker_compatibility(
     infer: Extension<Infer>,
     compute_type: Extension<ComputeType>,
     info: Extension<Info>,
+    served_model_name: Extension<String>,
     Json(req): Json<SagemakerRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     match req {
         SagemakerRequest::Generate(req) => {
-            compat_generate(default_return_full_text, infer, compute_type, Json(req)).await
+            compat_generate(default_return_full_text, infer, compute_type, served_model_name, Json(req)).await
         }
-        SagemakerRequest::Chat(req) => chat_completions(infer, compute_type, info, Json(req)).await,
+        SagemakerRequest::Chat(req) => chat_completions(infer, compute_type, info, served_model_name, Json(req)).await,
         SagemakerRequest::Completion(req) => {
-            completions(infer, compute_type, info, Json(req)).await
+            completions(infer, compute_type, info, served_model_name, Json(req)).await
         }
     }
 }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -129,6 +129,7 @@ pub(crate) async fn compat_generate(
     Extension(default_return_full_text): Extension<bool>,
     infer: Extension<Infer>,
     compute_type: Extension<ComputeType>,
+    served_model_name: Extension<String>,
     Json(mut req): Json<CompatGenerateRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     // default return_full_text given the pipeline_tag
@@ -138,11 +139,11 @@ pub(crate) async fn compat_generate(
 
     // switch on stream
     if req.stream {
-        Ok(generate_stream(infer, compute_type, Json(req.into()))
+        Ok(generate_stream(infer, served_model_name.clone(), compute_type, Json(req.into()))
             .await
             .into_response())
     } else {
-        let (headers, Json(generation)) = generate(infer, compute_type, Json(req.into())).await?;
+        let (headers, Json(generation)) = generate(infer, served_model_name.clone(), compute_type, Json(req.into())).await?;
         // wrap generation inside a Vec to match api-inference
         Ok((headers, Json(vec![generation])).into_response())
     }
@@ -196,9 +197,10 @@ async fn openai_get_model_info(info: Extension<Info>) -> Json<ModelsInfo> {
 )]
 async fn get_chat_tokenize(
     Extension(infer): Extension<Infer>,
+    Extension(served_model_name): Extension<String>,
     Json(chat): Json<ChatRequest>,
 ) -> Result<(HeaderMap, Json<ChatTokenizeResponse>), (StatusCode, Json<ErrorResponse>)> {
-    metrics::counter!("tgi_request_count").increment(1);
+    metrics::counter!("tgi_request_count", "model_name" => served_model_name).increment(1);
 
     let generate_request: GenerateRequest = chat.try_into_generate(&infer)?.0;
     let input = generate_request.inputs.clone();
@@ -270,23 +272,25 @@ seed,
 )]
 async fn generate(
     infer: Extension<Infer>,
+    served_model_name: Extension<String>,
     Extension(ComputeType(compute_type)): Extension<ComputeType>,
     Json(req): Json<GenerateRequest>,
 ) -> Result<(HeaderMap, Json<GenerateResponse>), (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
     let (headers, _, response) =
-        generate_internal(infer, ComputeType(compute_type), Json(req), span).await?;
+        generate_internal(infer, served_model_name, ComputeType(compute_type), Json(req), span).await?;
     Ok((headers, response))
 }
 
 pub(crate) async fn generate_internal(
     infer: Extension<Infer>,
+    served_model_name: Extension<String>,
     ComputeType(compute_type): ComputeType,
     Json(req): Json<GenerateRequest>,
     span: tracing::Span,
 ) -> Result<(HeaderMap, u32, Json<GenerateResponse>), (StatusCode, Json<ErrorResponse>)> {
     let start_time = Instant::now();
-    metrics::counter!("tgi_request_count").increment(1);
+    metrics::counter!("tgi_request_count", "model_name" => served_model_name.0.clone()).increment(1);
 
     // Do not long ultra long inputs, like image payloads.
     tracing::debug!(
@@ -305,10 +309,10 @@ pub(crate) async fn generate_internal(
     // Inference
     let (response, best_of_responses) = match req.parameters.best_of {
         Some(best_of) if best_of > 1 => {
-            let (response, best_of_responses) = infer.generate_best_of(req, best_of).await?;
+            let (response, best_of_responses) = infer.generate_best_of(req, best_of, served_model_name.0.clone()).await?;
             (response, Some(best_of_responses))
         }
-        _ => (infer.generate(req).await?, None),
+        _ => (infer.generate(req, served_model_name.0.clone()).await?, None),
     };
 
     // Token details
@@ -405,14 +409,14 @@ pub(crate) async fn generate_internal(
     );
 
     // Metrics
-    metrics::counter!("tgi_request_success").increment(1);
-    metrics::histogram!("tgi_request_duration").record(total_time.as_secs_f64());
-    metrics::histogram!("tgi_request_validation_duration").record(validation_time.as_secs_f64());
-    metrics::histogram!("tgi_request_queue_duration").record(queue_time.as_secs_f64());
-    metrics::histogram!("tgi_request_inference_duration").record(inference_time.as_secs_f64());
-    metrics::histogram!("tgi_request_mean_time_per_token_duration")
+    metrics::counter!("tgi_request_success", "model_name" => served_model_name.0.clone()).increment(1);
+    metrics::histogram!("tgi_request_duration", "model_name" => served_model_name.0.clone()).record(total_time.as_secs_f64());
+    metrics::histogram!("tgi_request_validation_duration", "model_name" => served_model_name.0.clone()).record(validation_time.as_secs_f64());
+    metrics::histogram!("tgi_request_queue_duration", "model_name" => served_model_name.0.clone()).record(queue_time.as_secs_f64());
+    metrics::histogram!("tgi_request_inference_duration", "model_name" => served_model_name.0.clone()).record(inference_time.as_secs_f64());
+    metrics::histogram!("tgi_request_mean_time_per_token_duration", "model_name" => served_model_name.0.clone())
         .record(time_per_token.as_secs_f64());
-    metrics::histogram!("tgi_request_generated_tokens")
+    metrics::histogram!("tgi_request_generated_tokens", "model_name" => served_model_name.0.clone())
         .record(response.generated_text.generated_tokens as f64);
 
     // Send response
@@ -468,6 +472,7 @@ seed,
 )]
 async fn generate_stream(
     Extension(infer): Extension<Infer>,
+    Extension(served_model_name): Extension<String>,
     Extension(compute_type): Extension<ComputeType>,
     Json(req): Json<GenerateRequest>,
 ) -> (
@@ -476,7 +481,7 @@ async fn generate_stream(
 ) {
     let span = tracing::Span::current();
     let (headers, response_stream) =
-        generate_stream_internal(infer, compute_type, Json(req), span).await;
+        generate_stream_internal(infer, served_model_name, compute_type, Json(req), span).await;
 
     let response_stream = async_stream::stream! {
         let mut response_stream = Box::pin(response_stream);
@@ -495,6 +500,7 @@ async fn generate_stream(
 
 async fn generate_stream_internal(
     infer: Infer,
+    served_model_name: String,
     ComputeType(compute_type): ComputeType,
     Json(req): Json<GenerateRequest>,
     span: tracing::Span,
@@ -503,7 +509,7 @@ async fn generate_stream_internal(
     impl Stream<Item = Result<StreamResponse, InferError>>,
 ) {
     let start_time = Instant::now();
-    metrics::counter!("tgi_request_count").increment(1);
+    metrics::counter!("tgi_request_count", "model_name" => served_model_name.clone()).increment(1);
 
     tracing::debug!("Input: {}", req.inputs);
 
@@ -540,7 +546,7 @@ async fn generate_stream_internal(
             tracing::error!("{err}");
             yield Err(err);
         } else {
-            match infer.generate_stream(req).instrument(info_span!(parent: &span, "async_stream")).await {
+            match infer.generate_stream(req, served_model_name.clone()).instrument(info_span!(parent: &span, "async_stream")).await {
                 // Keep permit as long as generate_stream lives
                 Ok((_permit, input_length, response_stream)) => {
                     let mut index = 0;
@@ -605,13 +611,13 @@ async fn generate_stream_internal(
                                         span.record("seed", format!("{:?}", generated_text.seed));
 
                                         // Metrics
-                                        metrics::counter!("tgi_request_success").increment(1);
-                                        metrics::histogram!("tgi_request_duration").record(total_time.as_secs_f64());
-                                        metrics::histogram!("tgi_request_validation_duration").record(validation_time.as_secs_f64());
-                                        metrics::histogram!("tgi_request_queue_duration").record(queue_time.as_secs_f64());
-                                        metrics::histogram!("tgi_request_inference_duration").record(inference_time.as_secs_f64());
-                                        metrics::histogram!("tgi_request_mean_time_per_token_duration").record(time_per_token.as_secs_f64());
-                                        metrics::histogram!("tgi_request_generated_tokens").record(generated_text.generated_tokens as f64);
+                                        metrics::counter!("tgi_request_success", "model_name" => served_model_name.clone()).increment(1);
+                                        metrics::histogram!("tgi_request_duration", "model_name" => served_model_name.clone()).record(total_time.as_secs_f64());
+                                        metrics::histogram!("tgi_request_validation_duration", "model_name" => served_model_name.clone()).record(validation_time.as_secs_f64());
+                                        metrics::histogram!("tgi_request_queue_duration", "model_name" => served_model_name.clone()).record(queue_time.as_secs_f64());
+                                        metrics::histogram!("tgi_request_inference_duration", "model_name" => served_model_name.clone()).record(inference_time.as_secs_f64());
+                                        metrics::histogram!("tgi_request_mean_time_per_token_duration", "model_name" => served_model_name.clone()).record(time_per_token.as_secs_f64());
+                                        metrics::histogram!("tgi_request_generated_tokens", "model_name" => served_model_name.clone()).record(generated_text.generated_tokens as f64);
 
                                         // StreamResponse
                                         end_reached = true;
@@ -704,10 +710,11 @@ pub(crate) async fn completions(
     Extension(infer): Extension<Infer>,
     Extension(compute_type): Extension<ComputeType>,
     Extension(info): Extension<Info>,
+    Extension(served_model_name): Extension<String>,
     Json(req): Json<CompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
-    metrics::counter!("tgi_request_count").increment(1);
+    metrics::counter!("tgi_request_count", "model_name" => served_model_name.clone()).increment(1);
 
     let CompletionRequest {
         model,
@@ -798,6 +805,7 @@ pub(crate) async fn completions(
             let infer_clone = infer.clone();
             let compute_type_clone = compute_type.clone();
             let span_clone = span.clone();
+            let served_model_name_clone = served_model_name.clone();
 
             // Create a future for each generate_stream_internal call.
             let generate_future = async move {
@@ -807,6 +815,7 @@ pub(crate) async fn completions(
                 tokio::spawn(async move {
                     let (headers, response_stream) = generate_stream_internal(
                         infer_clone.clone(),
+                        served_model_name_clone.clone(),
                         compute_type_clone.clone(),
                         Json(generate_request),
                         span_clone.clone(),
@@ -975,11 +984,13 @@ pub(crate) async fn completions(
         let responses = FuturesUnordered::new();
         for (index, generate_request) in generate_requests.into_iter().enumerate() {
             let infer_clone = infer.clone();
+            let served_model_name_clone = served_model_name.clone();
             let compute_type_clone = compute_type.clone();
             let span_clone = span.clone();
             let response_future = async move {
                 let result = generate_internal(
                     Extension(infer_clone),
+                    Extension(served_model_name_clone),
                     compute_type_clone,
                     Json(generate_request),
                     span_clone,
@@ -1230,10 +1241,11 @@ pub(crate) async fn chat_completions(
     Extension(infer): Extension<Infer>,
     Extension(compute_type): Extension<ComputeType>,
     Extension(info): Extension<Info>,
+    Extension(served_model_name): Extension<String>,
     Json(chat): Json<ChatRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
-    metrics::counter!("tgi_request_count").increment(1);
+    metrics::counter!("tgi_request_count", "model_name" => served_model_name.clone()).increment(1);
     let ChatRequest {
         model,
         stream,
@@ -1255,7 +1267,7 @@ pub(crate) async fn chat_completions(
     // switch on stream
     if stream {
         let (headers, response_stream) =
-            generate_stream_internal(infer, compute_type, Json(generate_request), span).await;
+            generate_stream_internal(infer, served_model_name, compute_type, Json(generate_request), span).await;
 
         // regex to match any function name
         let function_regex = match Regex::new(r#"\{"function":\{"_name":"([^"]+)""#) {
@@ -1389,7 +1401,7 @@ pub(crate) async fn chat_completions(
         Ok((headers, sse).into_response())
     } else {
         let (headers, input_length, Json(generation)) =
-            generate_internal(Extension(infer), compute_type, Json(generate_request), span).await?;
+            generate_internal(Extension(infer), Extension(served_model_name), compute_type, Json(generate_request), span).await?;
 
         let current_time = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1688,6 +1700,7 @@ pub async fn run(
     max_client_batch_size: usize,
     usage_stats_level: usage_stats::UsageStatsLevel,
     payload_limit: usize,
+    served_model_name: String,
 ) -> Result<(), WebServerError> {
     // CORS allowed origins
     // map to go inside the option and then map to parse from String to HeaderValue
@@ -1963,6 +1976,7 @@ pub async fn run(
         compat_return_full_text,
         allow_origin,
         payload_limit,
+        served_model_name,
     )
     .await;
 
@@ -2024,6 +2038,7 @@ async fn start(
     compat_return_full_text: bool,
     allow_origin: Option<AllowOrigin>,
     payload_limit: usize,
+    served_model_name: String,
 ) -> Result<(), WebServerError> {
     // Determine the server port based on the feature and environment variable.
     let port = if cfg!(feature = "google") {
@@ -2076,22 +2091,22 @@ async fn start(
         duration_buckets.push(value);
     }
     // Input Length buckets
-    let input_length_matcher = Matcher::Full(String::from("tgi_request_input_length"));
+    let input_length_matcher = Matcher::Full(format!("tgi_request_input_length{{model_name=\"{}\"}}", served_model_name));
     let input_length_buckets: Vec<f64> = (0..100)
         .map(|x| (max_input_tokens as f64 / 100.0) * (x + 1) as f64)
         .collect();
     // Generated tokens buckets
-    let generated_tokens_matcher = Matcher::Full(String::from("tgi_request_generated_tokens"));
+    let generated_tokens_matcher = Matcher::Full(format!("tgi_request_generated_tokens{{model_name=\"{}\"}}", served_model_name));
     let generated_tokens_buckets: Vec<f64> = (0..100)
         .map(|x| (max_total_tokens as f64 / 100.0) * (x + 1) as f64)
         .collect();
     // Input Length buckets
-    let max_new_tokens_matcher = Matcher::Full(String::from("tgi_request_max_new_tokens"));
+    let max_new_tokens_matcher = Matcher::Full(format!("tgi_request_max_new_tokens{{model_name=\"{}\"}}", served_model_name));
     let max_new_tokens_buckets: Vec<f64> = (0..100)
         .map(|x| (max_total_tokens as f64 / 100.0) * (x + 1) as f64)
         .collect();
     // Batch size buckets
-    let batch_size_matcher = Matcher::Full(String::from("tgi_batch_next_size"));
+    let batch_size_matcher = Matcher::Full(format!("ttgi_batch_next_size{{model_name=\"{}\"}}", served_model_name));
     let batch_size_buckets: Vec<f64> = (0..1024).map(|x| (x + 1) as f64).collect();
     // Speculated tokens buckets
     // let skipped_matcher = Matcher::Full(String::from("tgi_request_skipped_tokens"));
@@ -2334,7 +2349,8 @@ async fn start(
         .route("/v1/completions", post(completions))
         .route("/vertex", post(vertex_compatibility))
         .route("/invocations", post(sagemaker_compatibility))
-        .route("/tokenize", post(tokenize));
+        .route("/tokenize", post(tokenize))
+            .layer(Extension(served_model_name));
 
     if let Some(api_key) = api_key {
         let mut prefix = "Bearer ".to_string();


### PR DESCRIPTION
# What does this PR do?
Fixes:

1. model_name label is absent in metrics. Fixed this by adding the label in all the LLM metrics.
2. Added an optional argument served-model-name. If provided, model_name label is served_model_name, else defaulted to model_id

Issue link: https://github.com/huggingface/text-generation-inference/issues/3026
