### PR TITLE
fix(neuron): explicitly install toolchain

### DIFF
--- a/.github/workflows/ci_build.yaml
+++ b/.github/workflows/ci_build.yaml
@@ -20,6 +20,7 @@ on:
       - "Dockerfile"
       - "Dockerfile_amd"
       - "Dockerfile_intel"
+      - "Dockerfile.neuron"
     branches:
       - "main"
   workflow_dispatch:

--- a/Dockerfile.neuron
+++ b/Dockerfile.neuron
@@ -18,8 +18,7 @@ RUN apt-get update -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-COPY rust-toolchain.toml rust-toolchain.toml
-RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.85.0 --profile minimal -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo install cargo-chef --locked
 


### PR DESCRIPTION
# What does this PR do?

This reverts one change that was introduced in #3061 to avoid directly referencing the toolchain in the neuron Dockerfile (which is obviously a good idea), but actually broke the build.

I am open to any suggestion to improve this.