### PR TITLE
Add qwen2 multi lora layers support

### DIFF
--- a/server/text_generation_server/models/custom_modeling/flash_qwen2_modeling.py
+++ b/server/text_generation_server/models/custom_modeling/flash_qwen2_modeling.py
@@ -11,6 +11,8 @@ from text_generation_server.layers.attention import (
     Seqlen,
 )
 from text_generation_server.layers import (
+    TensorParallelMultiAdapterLinear,
+    TensorParallelAdapterRowLinear,
     TensorParallelRowLinear,
     TensorParallelColumnLinear,
     TensorParallelEmbedding,
@@ -23,18 +25,31 @@ from text_generation_server.layers.layernorm import (
 )
 
 
-def load_attention(config, prefix, weights):
+def load_attention(config, prefix, weights, layer_id):
+    prefixes = [f"{prefix}.q_proj", f"{prefix}.k_proj", f"{prefix}.v_proj"]
+    head_size = config.hidden_size // config.num_attention_heads
+    sizes = [
+        head_size * config.num_attention_heads,
+        head_size * config.num_key_value_heads,
+        head_size * config.num_key_value_heads,
+    ]
     if config.num_attention_heads != config.num_key_value_heads:
-        return _load_gqa(config, prefix, weights)
+        base_layer = _load_gqa(config, prefix, weights)
     else:
-        return TensorParallelColumnLinear.load_multi(
+        base_layer = TensorParallelColumnLinear.load_multi(
             config,
-            prefixes=[f"{prefix}.q_proj", f"{prefix}.k_proj", f"{prefix}.v_proj"],
+            prefixes=prefixes,
             dim=0,
             weights=weights,
             bias=True,
         )
-
+    return TensorParallelMultiAdapterLinear.load(
+        base_layer=base_layer,
+        layer_id=layer_id,
+        layer_names=prefixes,
+        sizes=sizes,
+        process_group=weights.process_group,
+    )
 
 def _load_gqa(config, prefix: str, weights):
     assert config.hidden_size % config.num_attention_heads == 0
@@ -52,6 +67,7 @@ def _load_gqa(config, prefix: str, weights):
 class Qwen2Attention(torch.nn.Module):
     def __init__(
         self,
+        index: int,
         prefix: str,
         config,
         weights,
@@ -83,15 +99,21 @@ class Qwen2Attention(torch.nn.Module):
             config.num_key_value_heads // weights.process_group.size()
         )
 
-        self.query_key_value = load_attention(config, prefix, weights)
+        self.query_key_value = load_attention(config, prefix, weights, index)
 
         self.kv_scales = get_kv_scales(weights, f"{prefix}")
 
-        self.o_proj = TensorParallelRowLinear.load(
+        o_proj = TensorParallelRowLinear.load(
             config,
             prefix=f"{prefix}.o_proj",
             weights=weights,
             bias=False,
+        )
+        self.o_proj = TensorParallelAdapterRowLinear.load(
+            o_proj,
+            index,
+            "o_proj",
+            process_group=weights.process_group,
         )
         self.num_groups = self.num_heads // self.num_key_value_heads
         self.kv_head_mapping = torch.arange(
@@ -110,8 +132,9 @@ class Qwen2Attention(torch.nn.Module):
         seqlen,
         max_s,
         prefill_cache_indices,
+        adapter_data
     ):
-        qkv = self.query_key_value(hidden_states)
+        qkv = self.query_key_value(hidden_states, adapter_data)
         query, kv = qkv.split(
             [
                 self.head_size * self.num_heads,
@@ -163,11 +186,13 @@ class Qwen2Attention(torch.nn.Module):
                 kv_scales=self.kv_scales,
             )
 
-        return self.o_proj(attn_output.view(-1, self.num_heads * self.head_size))
+        return self.o_proj(
+            attn_output.view(-1, self.num_heads * self.head_size), adapter_data
+        )
 
 
 class Qwen2MLP(nn.Module):
-    def __init__(self, prefix, config, weights):
+    def __init__(self, prefix, config, weights, index):
         super().__init__()
         act = config.hidden_act
         self.act = (
@@ -181,27 +206,45 @@ class Qwen2MLP(nn.Module):
             )
         )
         # Fuse gate and up proj
-        self.gate_up_proj = TensorParallelColumnLinear.load_multi(
+        prefixes = [f"{prefix}.gate_proj", f"{prefix}.up_proj"]
+        sizes = [
+            config.intermediate_size,
+            config.intermediate_size,
+        ]
+        gate_up_proj = TensorParallelColumnLinear.load_multi(
             config,
-            prefixes=[f"{prefix}.gate_proj", f"{prefix}.up_proj"],
+            prefixes=prefixes,
             weights=weights,
             dim=0,
             bias=False,
         )
-        self.down_proj = TensorParallelRowLinear.load(
+        self.gate_up_proj = TensorParallelMultiAdapterLinear.load(
+            gate_up_proj,
+            layer_id=index,
+            layer_names=prefixes,
+            sizes=sizes,
+            process_group=weights.process_group,
+        )
+        down_proj = TensorParallelRowLinear.load(
             config,
             prefix=f"{prefix}.down_proj",
             weights=weights,
             bias=False,
         )
+        self.down_proj = TensorParallelAdapterRowLinear.load(
+            down_proj,
+            index,
+            "down_proj",
+            process_group=weights.process_group,
+        )
         self.intermediate_size = (
             config.intermediate_size // weights.process_group.size()
         )
 
-    def forward(self, hidden_states):
-        gate_up_states = self.gate_up_proj(hidden_states)
+    def forward(self, hidden_states, adapter_data):
+        gate_up_states = self.gate_up_proj(hidden_states, adapter_data)
         gate_up_states = gate_up_states.view(-1, 2, self.intermediate_size)
-        return self.down_proj(self.act(gate_up_states[:, 0]) * gate_up_states[:, 1])
+        return self.down_proj(self.act(gate_up_states[:, 0]) * gate_up_states[:, 1], adapter_data)
 
 
 class Qwen2Layer(nn.Module):
@@ -209,9 +252,9 @@ class Qwen2Layer(nn.Module):
         super().__init__()
         prefix = f"{prefix}.layers.{layer_id}"
         self.self_attn = Qwen2Attention(
-            prefix=f"{prefix}.self_attn", config=config, weights=weights
+            index=layer_id, prefix=f"{prefix}.self_attn", config=config, weights=weights
         )
-        self.mlp = Qwen2MLP(prefix=f"{prefix}.mlp", config=config, weights=weights)
+        self.mlp = Qwen2MLP(prefix=f"{prefix}.mlp", config=config, weights=weights, index=layer_id)
         self.input_layernorm = FastRMSNorm.load(
             prefix=f"{prefix}.input_layernorm", weights=weights, eps=config.rms_norm_eps
         )
@@ -234,6 +277,7 @@ class Qwen2Layer(nn.Module):
         seqlen,
         max_s,
         prefill_cache_indices,
+        adapter_data,
     ):
         normed_hidden_states, residual = self.input_layernorm(hidden_states)
 
@@ -249,12 +293,13 @@ class Qwen2Layer(nn.Module):
             seqlen,
             max_s,
             prefill_cache_indices,
+            adapter_data
         )
         hidden_states = attn_output + residual
 
         # faster post attention rms norm
         hidden_states, residual = self.post_attention_layernorm(hidden_states)
-        mlp_output = self.mlp(hidden_states)
+        mlp_output = self.mlp(hidden_states, adapter_data)
         hidden_states = mlp_output + residual
         return hidden_states
 
@@ -301,6 +346,7 @@ class Qwen2Model(torch.nn.Module):
         max_s: int,
         true_max_s: int,
         prefill_cache_indices: Optional[torch.Tensor],
+        adapter_data,
     ) -> torch.Tensor:
         hidden_states = inputs_embeds
 
@@ -324,6 +370,7 @@ class Qwen2Model(torch.nn.Module):
                 seqlen,
                 max_s,
                 prefill_cache_indices,
+                adapter_data,
             )
 
         hidden_states, _ = self.norm(hidden_states)
@@ -396,6 +443,7 @@ class Qwen2ForCausalLM(torch.nn.Module):
             max_s,
             true_max_s,
             prefill_cache_indices,
+            adapter_data,
         )
         if lm_head_indices is not None:
             hidden_states = hidden_states[lm_head_indices]


### PR DESCRIPTION
Add qwen2 multi lora layers support to solve problem like [https://github.com/huggingface/text-generation-inference/issues/2881](https://github.com/huggingface/text-generation-inference/issues/2881), the similar PR is at [https://github.com/huggingface/text-generation-inference/pull/2883](https://github.com/huggingface/text-generation-inference/pull/2883)

# What does this PR do?

I attempted to serve the Qwen LLM following the blog [https://huggingface.co/blog/multi-lora-serving](https://huggingface.co/blog/multi-lora-serving), I use the latest Docker image: `docker pull ghcr.io/huggingface/text-generation-inference:sha-622908d`.My hardware is NVIDIA A100 80G, with NVIDIA driver and CUDA version 12.4, and the operating system is CentOS 7.

And my script is as follows:

```shell
#!/bin/zsh

# ./0.run_huggingface_model.sh -m $HOME/Models/Qwen2.5-7B-Instruct -l $HOME/Source/dpo_tuned_llm/final_lora_checkpoint

# Exit the script immediately if any command fails
set -e

# Initialize variables
model_path=""
lora_path=""
gpu_devices='"device=4,5"'
help_message="Usage: run_huggingface_model.sh [-m model_path] [-l lora_path] [-g gpu_devices] [-h]
Options:
    -m --model  Specify the model path to be used in the Docker container.
    -l --lora   Specify the lora path to be used in the Docker container.
    -g --gpus   Specify the GPU devices to be used by the Docker container (default is 'device=4,5').
    -h --help   Display this help message."

# Parse command line arguments
while [[ $# -gt 0 ]]; do
    case "$1" in
        -m|--model)
            model_path="$2"
            shift 2
            ;;
        -l|--lora)
            lora_path="$2"
            shift 2
            ;;
        -g|--gpus)
            gpu_devices="$2"
            shift 2
            ;;
        -h|--help)
            echo "$help_message"
            exit 0
            ;;
        *)
            echo "Unknown option: $1"
            echo "$help_message"
            exit 1
            ;;
    esac
done

# Check if model_path is provided
if [[ -z "$model_path" ]]; then
    echo "Error: Model path is required."
    echo "$help_message"
    exit 1
fi

# Check if lora_path is provided
if [[ -z "$lora_path" ]]; then
    echo "Error: Lora path is required."
    echo "$help_message"
    exit 1
fi

# Verify that the model_path exists and is a directory
if [[ ! -d "$model_path" ]]; then
    echo "Error: The specified model path '$model_path' does not exist or is not a directory."
    exit 1
fi

# Verify that the lora_path exists and is a directory
if [[ ! -d "$lora_path" ]]; then
    echo "Error: The specified lora path '$lora_path' does not exist or is not a directory."
    exit 1
fi

# Extract the last component of the model_path and lora_path
model_last_component=${model_path%/}
model_last_component=${model_last_component##*/}
lora_last_component=${lora_path%/}
lora_last_component=${lora_last_component##*/}

# Define the symbolic link path in ./
model_symlink_path="./${model_last_component}_link"
lora_symlink_path="./${lora_last_component}_link"

# Create or update the symbolic link, forcing overwrite if it exists
ln -sf "$model_path" "$model_symlink_path"
ln -sf "$lora_path" "$lora_symlink_path"

# Define a cleanup function to remove the symbolic link upon script exit
cleanup() {
    echo "Removing symbolic link '$model_symlink_path' '$lora_symlink_path'..."
    rm -f "$model_symlink_path"
    rm -f "$lora_symlink_path"
}

# Ensure the cleanup function runs when the script exits
trap cleanup EXIT

# Retrieve the first IP address of the host
HOST_IP=$(hostname -I | awk '{print $1}')

# Print debugging information
echo "model_last_component: '$model_last_component'"
echo "lora_last_component: '$lora_last_component'"
echo "HOST_IP: '$HOST_IP'"
echo "Using GPU devices: $gpu_devices"

# Run the Docker container with the specified configurations
docker run --gpus "$gpu_devices" --shm-size 1g -p 8080:80 \
    -v "$model_symlink_path:/data/$model_last_component" \
    -v "$lora_symlink_path:/data/$lora_last_component" \
    ghcr.io/huggingface/text-generation-inference \
        --model-id "/data/$model_last_component" \
        --lora-adapters "myadapter=/data/$lora_last_component"
```

However, I encountered the same error as described in [this link](https://github.com/huggingface/text-generation-inference/issues/2881):

![image](https://github.com/user-attachments/assets/a13dd45b-4549-4d99-ac3f-6c8cfeb2a25f)

Fixes # (issue)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
    [https://discuss.huggingface.co/t/attributeerror-tensorparallelcolumnlinear-object-has-no-attribute-base-layer/112492](https://discuss.huggingface.co/t/attributeerror-tensorparallelcolumnlinear-object-has-no-attribute-base-layer/112492)
    [https://github.com/huggingface/text-generation-inference/issues/2881](https://github.com/huggingface/text-generation-inference/issues/2881)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

I pulled the main branch and built a container.
```bash
docker build -f Dockerfile -t text-generation-inference:qwen2_multi_lora_layers_support .
```

I successfully served the Qwen2/2.5 7B model using this container. However, this only ensures that the serving code can run properly, and it does not guarantee that I have checked the correctness of the Lora loading. I kindly request further verification.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
