### PR TITLE
feat: align function id with tool call response

### DIFF
--- a/router/src/chat.rs
+++ b/router/src/chat.rs
@@ -49,6 +49,7 @@ pub(crate) fn parse_output(generated_text: &str) -> Result<ChatChoice, InferErro
                 id: "0".to_string(),
                 r#type: "function".to_string(),
                 function: FunctionDefinition {
+                    id: None,
                     description: None,
                     name: name.to_string(),
                     arguments: serde_json::to_value(call.function.arguments).map_err(|err| {

--- a/router/src/infer/chat_template.rs
+++ b/router/src/infer/chat_template.rs
@@ -96,15 +96,21 @@ impl ChatTemplate {
 
         let messages: Vec<TextMessage> = messages.into_iter().map(|c| c.into()).collect();
         let final_message = messages.last().cloned();
+        let template_inputs = ChatTemplateInputs {
+            messages,
+            bos_token: self.bos_token.as_deref(),
+            eos_token: self.eos_token.as_deref(),
+            add_generation_prompt: true,
+            tools,
+        };
+
+        // NOTE: initalizing `template_inputs` is helpful when JSON dumping the
+        // `ChatTemplateInputs` struct for debugging
+        // let template_inputs_as_json = serde_json::to_string(&template_inputs).unwrap();
+
         let mut rendered_template = self
             .template
-            .render(ChatTemplateInputs {
-                messages,
-                bos_token: self.bos_token.as_deref(),
-                eos_token: self.eos_token.as_deref(),
-                add_generation_prompt: true,
-                tools,
-            })
+            .render(template_inputs)
             .map_err(InferError::TemplateError)?;
 
         // if the last message is from the assistant, continue the generation prompt

--- a/router/src/infer/tool_grammar.rs
+++ b/router/src/infer/tool_grammar.rs
@@ -34,6 +34,7 @@ impl ToolGrammar {
                     .chain(std::iter::once(Tool {
                         r#type: "function".to_string(),
                         function: FunctionDefinition {
+                            id: None,
                             name: "no_tool".to_string(),
                             description: Some(
                                 "Open ended response with no specific tool selected".to_string(),

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1165,8 +1165,7 @@ pub(crate) async fn chat_completions(
 
     tracing::debug!("Got chat_template {:?}", infer.chat_template);
     let id = chat.next_tool_call_id();
-    let (generate_request, using_tools): (GenerateRequest, bool) =
-        chat.clone().try_into_generate(&infer)?;
+    let (generate_request, using_tools) = chat.clone().try_into_generate(&infer)?;
     span.record("parameters", format!("{:?}", generate_request.parameters));
     let logprobs = logprobs.unwrap_or_default();
 
@@ -1188,7 +1187,7 @@ pub(crate) async fn chat_completions(
 
         let response_stream = async_stream::stream! {
             let mut response_stream = Box::pin(response_stream);
-            let mut state = ChatState::new(using_tools, stream_options.clone(), system_fingerprint.clone(), model_id.clone(), logprobs, id.clone());
+            let mut state = ChatState::new(using_tools.is_some(), stream_options.clone(), system_fingerprint.clone(), model_id.clone(), logprobs, id.clone());
             while let Some(result) = response_stream.next().await {
                 match result{
                 Ok(stream_token) => {
@@ -1197,12 +1196,12 @@ pub(crate) async fn chat_completions(
                         ChatEvent::NoTool => {
                             chat.tools = None;
                             chat.response_format = None;
-                            let (generate_request, using_tools): (GenerateRequest, bool) =
+                            let (generate_request, using_tools)  =
                                 chat.clone().try_into_generate(&infer).unwrap();
-                            assert!(!using_tools);
+                            assert!(using_tools.is_none());
                             let (_headers, response_stream2) =
                                 generate_stream_internal(infer.clone(), compute_type.clone(), Json(generate_request), span.clone()).await;
-                            state = ChatState::new(using_tools, stream_options.clone(), system_fingerprint.clone(), model_id.clone(), logprobs, id.clone());
+                            state = ChatState::new(using_tools.is_some(), stream_options.clone(), system_fingerprint.clone(), model_id.clone(), logprobs, id.clone());
                             response_stream = Box::pin(response_stream2);
                         }
                         ChatEvent::Events(events) => {
@@ -1237,14 +1236,13 @@ pub(crate) async fn chat_completions(
             .unwrap_or_else(|_| std::time::Duration::from_secs(0))
             .as_secs();
 
-        let (tool_calls, output) = if using_tools {
+        let (tool_calls, output) = if using_tools.is_some() {
             match crate::chat::parse_output(&generation.generated_text)? {
                 ChatChoice::NoTool => {
                     chat.tools = None;
                     chat.response_format = None;
-                    let (generate_request, using_tools): (GenerateRequest, bool) =
-                        chat.clone().try_into_generate(&infer)?;
-                    assert!(!using_tools);
+                    let (generate_request, using_tools) = chat.clone().try_into_generate(&infer)?;
+                    assert!(using_tools.is_none());
                     let (headers_final, input_length_final, Json(generation)) = generate_internal(
                         Extension(infer),
                         compute_type,
@@ -1256,7 +1254,16 @@ pub(crate) async fn chat_completions(
                     input_length = input_length_final;
                     (None, Some(generation.generated_text))
                 }
-                ChatChoice::ToolCalls(tool_calls) => (Some(tool_calls), None),
+                ChatChoice::ToolCalls(mut tool_calls) => {
+                    // assign the tool ids based on the tool names
+                    tool_calls.iter_mut().for_each(|tool_call| {
+                        tool_call.id = using_tools
+                            .as_ref()
+                            .and_then(|tools| tools.get(&tool_call.function.name))
+                            .map_or("0".to_string(), |id| id.clone());
+                    });
+                    (Some(tool_calls), None)
+                }
             }
         } else {
             (None, Some(generation.generated_text))

--- a/router/src/vertex.rs
+++ b/router/src/vertex.rs
@@ -104,8 +104,7 @@ pub(crate) async fn vertex_compatibility(
                 },
             },
             VertexInstance::Chat(instance) => {
-                let (generate_request, _using_tools): (GenerateRequest, bool) =
-                    instance.try_into_generate(&infer)?;
+                let (generate_request, _using_tools) = instance.try_into_generate(&infer)?;
                 generate_request
             }
         };


### PR DESCRIPTION
This PR improve mapping of tool ids to responses and enables tool_call_ids to be included in templates


Changes:
1. maps input `tool.id` to `tool_calls[0].id` for chosen tool if `tool.id` is sepcified
2. includes `tool_call_id` in chat template in the case an id is required


### 1. map tool id to tool response

```python
import requests
import json

messages = [
    {
        "role": "system",
        "content": "You're a human assistant helping a user with a task. Use the tools to complete the task.",
    },
    {"role": "user", "content": "What's the weather like in Boston today?"},
]

payload = dict(
    messages=messages,
    seed=42,
    max_tokens=40,
    tools=[
        {
            "type": "function",
            "function": {
                "id": "TOOL_ID_01",
                "name": "get_current_weather",
                "description": "Get the current weather",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "location": {
                            "type": "string",
                            "description": "The city and state, e.g. San Francisco, CA",
                        },
                        "format": {
                            "type": "string",
                            "enum": ["celsius", "fahrenheit"],
                            "description": "The temperature unit to use. Infer this from the users location.",
                        },
                    },
                    "required": ["location", "format"],
                },
            },
        }
    ],
)

response = requests.post(
    "http://127.0.0.1:3000/v1/chat/completions",
    json=payload,
    headers={"Content-Type": "application/json"},
)

print(json.dumps(response.json(), indent=2))
```

returns a response with the specified tool id

```json
{
  "object": "chat.completion",
  "id": "",
  "created": 1741893608,
  "model": "mistralai/Mistral-7B-Instruct-v0.3",
  "system_fingerprint": "3.2.1-dev0-native",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "tool_calls": [
          {
            "id": "TOOL_ID_01",
            "type": "function",
            "function": {
              "description": null,
              "name": "get_current_weather",
              "arguments": "{\"location\":\"Boston, MA\",\"format\":\"celsius\"}"
            }
          }
        ]
      },
      "logprobs": null,
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 261,
    "completion_tokens": 34,
    "total_tokens": 295
  }
}
```

### 2.  include `tool_call_id` in chat template

```python
import requests
import json

messages = [
    {
        "role": "system",
        "content": "You're a human assistant helping a user with a task. Use the tools to complete the task.",
    },
    {"role": "user", "content": "What's the weather like in Boston today?"},
    {
        "role": "assistant",
        "tool_calls": [
            {
                "id": "TOOL_ID_1",
                "type": "function",
                "function": {
                    "description": None,
                    "name": "get_current_weather",
                    "arguments": '{"location":"Boston, MA","format":"celsius"}',
                },
            }
        ],
    },
    {
        "role": "tool",
        "tool_call_id": "TOOL_ID_1",
        "content": "-1C",
    },
]

payload = dict(
    messages=messages,
    seed=42,
    max_tokens=40,
    tools=[
        {
            "type": "function",
            "function": {
                "id": "TOOL_ID_1",
                "name": "get_current_weather",
                "description": "Get the current weather",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "location": {
                            "type": "string",
                            "description": "The city and state, e.g. San Francisco, CA",
                        },
                        "format": {
                            "type": "string",
                            "enum": ["celsius", "fahrenheit"],
                            "description": "The temperature unit to use. Infer this from the users location.",
                        },
                    },
                    "required": ["location", "format"],
                },
            },
        }
    ],
    # force a non tool response in the case the last message was a tool response
    tool_choice="none" if messages[-1]["role"] == "tool" else "auto",
)

response = requests.post(
    "http://127.0.0.1:3000/v1/chat/completions",
    json=payload,
    headers={"Content-Type": "application/json"},
)

print(json.dumps(response.json(), indent=2))
```

returns a natural language response that internal included the tool call id in the prompt

```json
{
  "object": "chat.completion",
  "id": "",
  "created": 1741893739,
  "model": "mistralai/Mistral-7B-Instruct-v0.3",
  "system_fingerprint": "3.2.1-dev0-native",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "The weather in Boston today is -1 degrees Celsius."
      },
      "logprobs": null,
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 100,
    "completion_tokens": 14,
    "total_tokens": 114
  }
}
```

without these changes the response from `mistralai/Mistral-7B-Instruct-v0.3` (which requires an ID of a specific length)

```json
{
  "error": "Template error: syntax error: Tool call IDs should be alphanumeric strings with length 9! (in <string>:81)",
  "error_type": "template_error"
}
```
