### PR TITLE
CI: enable server tests for backends

### DIFF
--- a/.github/workflows/nix_tests.yaml
+++ b/.github/workflows/nix_tests.yaml
@@ -7,6 +7,7 @@ on:
       - "proto/**"
       - "router/**"
       - "launcher/**"
+      - "backends/**"
       - "Cargo.lock"
       - "rust-toolchain.toml"
 concurrency:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ on:
       - "proto/**"
       - "router/**"
       - "launcher/**"
+      - "backends/**"
       - "Cargo.lock"
       - "rust-toolchain.toml"
 


### PR DESCRIPTION
# What does this PR do?

Previously, the backends were not covered by the server tests. Now that they play a more significant role with TGI’s new multi-backend support, it would be beneficial to include them in the tests as well.

This update in part introduces a pre-commit check to enforce proper styling for backend-related PRs.