### PR TITLE
Fix flashinfer plan call to use positional arguments for #3165

### DIFF
--- a/server/text_generation_server/layers/attention/flashinfer.py
+++ b/server/text_generation_server/layers/attention/flashinfer.py
@@ -84,16 +84,16 @@ def use_prefill_with_paged_kv_state(
     token = prefill_with_paged_kv_state.set(state)
     try:
         state.plan(
-            qo_indptr=cu_seqlens,
-            paged_kv_indptr=indptr,
-            paged_kv_indices=block_tables,
-            paged_kv_last_page_len=last_page_len,
-            num_qo_heads=num_heads,
-            num_kv_heads=num_kv_heads,
-            head_dim=head_size,
-            kv_data_type=kv_dtype,
+            cu_seqlens,
+            indptr,
+            block_tables,
+            last_page_len,
+            num_heads,
+            num_kv_heads,
+            head_size,
+            page_size,
             q_data_type=q_dtype,
-            page_size=page_size,
+            kv_data_type=kv_dtype,
         )
         yield
     finally:


### PR DESCRIPTION
# What does this PR do?

This changes the call to BatchPrefillWithPagedKVCacheWrapper.plan to use positional arguments instead of key value arguments.  Not sure why python is acting like this

Fixes #3165 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@Narsil @danieldk - please review

