### PR TITLE
forward and tokenize chooser use the same shape

### DIFF
--- a/backends/gaudi/server/text_generation_server/layers/attention/__init__.py
+++ b/backends/gaudi/server/text_generation_server/layers/attention/__init__.py
@@ -3,6 +3,7 @@ from .common import (
     HPUPagedAttentionMetadata,
     trim_attn_metadata,
     trim_seqlen_metadata,
+    _async_h2d_tensor_copy,
 )
 
 from .hpu import (
@@ -25,4 +26,5 @@ __all__ = [
     "HPUPagedAttentionMetadata",
     "trim_seqlen_metadata",
     "trim_attn_metadata",
+    "_async_h2d_tensor_copy",
 ]

--- a/backends/gaudi/server/text_generation_server/utils/tokens.py
+++ b/backends/gaudi/server/text_generation_server/utils/tokens.py
@@ -552,8 +552,13 @@ def pad_next_token_chooser_parameters(
 
 class Sampling:
     def __init__(self, seed: int, device: str = "cpu"):
-        self.generator = torch.Generator("cpu")
-        self.generator.manual_seed(seed)
+        if device in ["hpu", torch.device("hpu")]:
+            import habana_frameworks.torch.hpu.random as htrandom
+
+            self.generator = htrandom.default_generators[0].manual_seed(seed)
+        else:
+            self.generator = torch.Generator("cpu")
+            self.generator.manual_seed(seed)
         self.seed = seed
 
     def __call__(self, logits):


### PR DESCRIPTION
text-generation-launcher --model-id=meta-llama/Llama-3.1-8B-Instruct -p 8080  --max-input-tokens 512 --max-total-tokens 1024 --max-batch-size 64 --max-batch-prefill-tokens 4096


python benchmark_serving.py --backend tgi --model meta-llama/Llama-3.1-8B-Instruct --trust-remote-code --dataset-name random --random-input-len 512 --random-output-len 512 --request-rate inf --num-prompts 64 --endpoint /generate_stream --host 0.0.0.0 --port 8080 --ignore-eos

perf improvement 20% due to remove dynamic shape change in hpu in concate/filter