### PR TITLE
fix: bump snaps for mllama

### DIFF
--- a/integration-tests/models/__snapshots__/test_mllama/test_mllama_load.json
+++ b/integration-tests/models/__snapshots__/test_mllama/test_mllama_load.json
@@ -14,11 +14,11 @@
         "usage": null
       }
     ],
-    "created": 1739290197,
+    "created": 1746054921,
     "id": "",
     "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
     "object": "chat.completion",
-    "system_fingerprint": "3.1.1-dev0-native",
+    "system_fingerprint": "3.2.3-dev0-native",
     "usage": {
       "completion_tokens": 10,
       "prompt_tokens": 45,
@@ -40,11 +40,11 @@
         "usage": null
       }
     ],
-    "created": 1739290197,
+    "created": 1746054921,
     "id": "",
     "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
     "object": "chat.completion",
-    "system_fingerprint": "3.1.1-dev0-native",
+    "system_fingerprint": "3.2.3-dev0-native",
     "usage": {
       "completion_tokens": 10,
       "prompt_tokens": 45,

--- a/integration-tests/models/__snapshots__/test_mllama/test_mllama_simpl.json
+++ b/integration-tests/models/__snapshots__/test_mllama/test_mllama_simpl.json
@@ -5,7 +5,7 @@
       "index": 0,
       "logprobs": null,
       "message": {
-        "content": "A chicken sits on a pile of money, looking",
+        "content": "A chicken stands on a pile of money, looking",
         "name": null,
         "role": "assistant",
         "tool_calls": null
@@ -13,11 +13,11 @@
       "usage": null
     }
   ],
-  "created": 1739290152,
+  "created": 1746054919,
   "id": "",
   "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
   "object": "chat.completion",
-  "system_fingerprint": "3.1.1-dev0-native",
+  "system_fingerprint": "3.2.3-dev0-native",
   "usage": {
     "completion_tokens": 10,
     "prompt_tokens": 45,

--- a/integration-tests/models/test_mllama.py
+++ b/integration-tests/models/test_mllama.py
@@ -48,7 +48,7 @@ async def test_mllama_simpl(mllama, response_snapshot):
     }
     assert (
         response.choices[0].message.content
-        == "A chicken sits on a pile of money, looking"
+        == "A chicken stands on a pile of money, looking"
     )
     assert response == response_snapshot
 


### PR DESCRIPTION
This PR simply bumps the snaps for mllama as one token has changed in the generation

**exact root cause is still to be determined 