### PR TITLE
Skip `{% generation %}` and `{% endgeneration %}` template handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 target
 router/tokenizer.json
 *__pycache__*
-.DS_Store
 
 backends/v2/src/client/pb
 backends/v3/src/client/pb

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target
 router/tokenizer.json
 *__pycache__*
+.DS_Store
 
 backends/v2/src/client/pb
 backends/v3/src/client/pb

--- a/router/src/infer/chat_template.rs
+++ b/router/src/infer/chat_template.rs
@@ -47,9 +47,8 @@ impl ChatTemplate {
         let mutated_template = mutated_template.replace("[::-1]", "|reverse");
         // TODO: replace with a better solution
         // Hack to remove the {% generation %} and {% endgeneration %} statements from
-        // Phi4 Reasoning chat templates, as those are required when generating a mask
-        // for the assistant generated tokens, not natively handled yet
-        // Reference from Transformers at https://github.com/huggingface/transformers/blob/7a3e208892c06a5e278144eaf38c8599a42f53e7/src/transformers/processing_utils.py#L382-L385
+        // the Jinja2 chat templates if there, since those are only using for assistant
+        // masking during training, and should be ignored during inference
         let mutated_template = mutated_template.replace("{% generation %}", "");
         let mutated_template = mutated_template.replace("{% endgeneration %}", "");
 

--- a/router/src/infer/chat_template.rs
+++ b/router/src/infer/chat_template.rs
@@ -45,6 +45,13 @@ impl ChatTemplate {
         //  It uses python notation to reverse lists, which do not exist in minijinja
         //  so we're using the reverse filter instead.
         let mutated_template = mutated_template.replace("[::-1]", "|reverse");
+        // TODO: replace with a better solution
+        // Hack to remove the {% generation %} and {% endgeneration %} statements from
+        // Phi4 Reasoning chat templates, as those are required when generating a mask
+        // for the assistant generated tokens, not natively handled yet
+        // Reference from Transformers at https://github.com/huggingface/transformers/blob/7a3e208892c06a5e278144eaf38c8599a42f53e7/src/transformers/processing_utils.py#L382-L385
+        let mutated_template = mutated_template.replace("{% generation %}", "");
+        let mutated_template = mutated_template.replace("{% endgeneration %}", "");
 
         let template_str = mutated_template.into_boxed_str();
         env.add_function("raise_exception", raise_exception);


### PR DESCRIPTION
# What does this PR do?

This PR is just a tentative fix for both `{% generation %}` and `{% endgeneration %}` custom syntax introduced within some chat templates for [returning a mask of the assistant generated tokens](https://github.com/huggingface/transformers/blob/7a3e208892c06a5e278144eaf38c8599a42f53e7/src/transformers/processing_utils.py#L382-L385) which is only useful during training and should indeed be ignored during inference, affecting models as e.g. [`microsoft/Phi-4-reasoning-plus`](https://huggingface.co/microsoft/Phi-4-reasoning-plus).

Thanks to @Rocketknight1 for the explanation!

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil