### PR TITLE
Migrate to V2 Pydantic interface

### DIFF
--- a/docs/source/basic_tutorials/using_guidance.md
+++ b/docs/source/basic_tutorials/using_guidance.md
@@ -138,10 +138,10 @@ client = InferenceClient("http://localhost:3000")
 
 user_input = "I saw a puppy a cat and a raccoon during my bike ride in the park"
 resp = client.text_generation(
-    f"convert to JSON: 'f{user_input}'. please use the following schema: {Animals.schema()}",
+    f"convert to JSON: 'f{user_input}'. please use the following schema: {Animals.model_json_schema()}",
     max_new_tokens=100,
     seed=42,
-    grammar={"type": "json", "value": Animals.schema()},
+    grammar={"type": "json", "value": Animals.model_json_schema()},
 )
 
 print(resp)

--- a/integration-tests/models/test_grammar_response_format_llama.py
+++ b/integration-tests/models/test_grammar_response_format_llama.py
@@ -34,7 +34,7 @@ async def test_grammar_response_format_llama_json(llama_grammar, response_snapsh
         "messages": [
             {
                 "role": "system",
-                "content": f"Respond to the users questions and answer them in the following format: {Weather.schema()}",
+                "content": f"Respond to the users questions and answer them in the following format: {Weather.model_json_schema()}",
             },
             {
                 "role": "user",
@@ -43,7 +43,7 @@ async def test_grammar_response_format_llama_json(llama_grammar, response_snapsh
         ],
         "seed": 42,
         "max_tokens": 500,
-        "response_format": {"type": "json_object", "value": Weather.schema()},
+        "response_format": {"type": "json_object", "value": Weather.model_json_schema()},
     }
     # send the request
     response = requests.post(
@@ -75,7 +75,7 @@ async def test_grammar_response_format_llama_json(llama_grammar, response_snapsh
 
     json_payload["response_format"] = {
         "type": "json_schema",
-        "value": {"name": "weather", "strict": True, "schema": Weather.schema()},
+        "value": {"name": "weather", "strict": True, "schema": Weather.model_json_schema()},
     }
     response = requests.post(
         f"{llama_grammar.base_url}/v1/chat/completions",
@@ -109,7 +109,7 @@ async def test_grammar_response_format_llama_error_if_tools_not_installed(
             "messages": [
                 {
                     "role": "system",
-                    "content": f"Respond to the users questions and answer them in the following format: {Weather.schema()}",
+                    "content": f"Respond to the users questions and answer them in the following format: {Weather.model_json_schema()}",
                 },
                 {
                     "role": "user",
@@ -119,7 +119,7 @@ async def test_grammar_response_format_llama_error_if_tools_not_installed(
             "seed": 42,
             "max_tokens": 500,
             "tools": [],
-            "response_format": {"type": "json_object", "value": Weather.schema()},
+            "response_format": {"type": "json_object", "value": Weather.model_json_schema()},
         },
     )
 


### PR DESCRIPTION
# What does this PR do?
This PR updates Pydantic V1 `Model.schema()` calls to the Pydantic V2 equivalent `Model.model_json_schema()` to resolve `PydanticDeprecatedSince20` warnings.

**Changes Made:**

- Replaced `Animals.schema()` with `Animals.model_json_schema()` in `docs/source/basic_tutorials/using_guidance.md`.
- Replaced multiple instances of `Weather.schema()` with `Weather.model_json_schema()` in `integration-tests/models/test_grammar_response_format_llama.py`.

These changes ensure compatibility with Pydantic V2+ and address deprecation warnings related to the `Model.schema()` method, as observed in [CI logs](https://github.com/huggingface/text-generation-inference/actions/runs/15493448831/job/43631849416#step:6:11817).
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
