### PR TITLE
Disable mamba in CPU platform

### DIFF
--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -189,11 +189,14 @@ if FLASH_ATTENTION:
     __all__.append(IdeficsCausalLM)
 
 MAMBA_AVAILABLE = True
-try:
-    from text_generation_server.models.mamba import Mamba
-except ImportError as e:
-    log_master(logger.warning, f"Could not import Mamba: {e}")
+if SYSTEM == "cpu":
     MAMBA_AVAILABLE = False
+else:
+    try:
+        from text_generation_server.models.mamba import Mamba
+    except ImportError as e:
+        log_master(logger.warning, f"Could not import Mamba: {e}")
+        MAMBA_AVAILABLE = False
 
 if MAMBA_AVAILABLE:
     __all__.append(Mamba)


### PR DESCRIPTION
# What does this PR do?


Mamba relies on mamba_sse which uses triton. Given triton is not compatible in CPU (fails with `RuntimeError: 0 active drivers ([]). There should only be one.`), we shouldn't try to activate it if we are on CPU.

I can also push this guard into mamba.py but seems easy enough to do here.

Similar issues on other projects: https://github.com/deepspeedai/DeepSpeed/issues/7028#issuecomment-2836835225


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ X ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
