### PR TITLE
HuggingFaceM4/Idefics3-8B-Llama3 crash fix

### DIFF
--- a/router/src/config.rs
+++ b/router/src/config.rs
@@ -265,6 +265,10 @@ impl Idefics3 {
     pub fn get_max_longest_edge_for_image_resize(&self) -> usize {
         1456
     }
+
+    pub fn get_max_image_size(&self) -> usize {
+        4096
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -646,11 +646,10 @@ fn image_tokens(
             const GLOBAL_IMG: &str = "<global-img>";
 
             let max_longest_edge_for_image_resize = config.get_max_longest_edge_for_image_resize();
+            let max_image_size = config.get_max_image_size();
 
-            // resize image if it is larger than max_longest_edge_for_image_resize keeping aspect ratio
-            let (height, width) = if height > max_longest_edge_for_image_resize
-                || width > max_longest_edge_for_image_resize
-            {
+            // resize image to max_longest_edge_for_image_resize and keep aspect ratio
+            let (height, width) = {
                 let aspect_ratio = height as f32 / width as f32;
                 if height > width {
                     (
@@ -663,8 +662,23 @@ fn image_tokens(
                         max_longest_edge_for_image_resize,
                     )
                 }
-            } else {
-                (height, width)
+            };
+
+            let (height, width) = {
+                let aspect_ratio = height as f32 / width as f32;
+                if height >= width && height > max_image_size {
+                    (
+                        max_image_size,
+                        (max_image_size as f32 / aspect_ratio) as usize,
+                    )
+                } else if width > height && width > max_image_size {
+                    (
+                        (max_image_size as f32 * aspect_ratio) as usize,
+                        max_image_size,
+                    )
+                } else {
+                    (height, width)
+                }
             };
 
             let image_seq_len = config.get_number_of_features();

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -648,37 +648,18 @@ fn image_tokens(
             let max_longest_edge_for_image_resize = config.get_max_longest_edge_for_image_resize();
             let max_image_size = config.get_max_image_size();
 
-            // resize image to max_longest_edge_for_image_resize and keep aspect ratio
             let (height, width) = {
-                let aspect_ratio = height as f32 / width as f32;
-                if height > width {
-                    (
-                        max_longest_edge_for_image_resize,
-                        (max_longest_edge_for_image_resize as f32 / aspect_ratio) as usize,
-                    )
-                } else {
-                    (
-                        (max_longest_edge_for_image_resize as f32 * aspect_ratio) as usize,
-                        max_longest_edge_for_image_resize,
-                    )
-                }
-            };
+                let h = height as f32;
+                let w = width as f32;
 
-            let (height, width) = {
-                let aspect_ratio = height as f32 / width as f32;
-                if height >= width && height > max_image_size {
-                    (
-                        max_image_size,
-                        (max_image_size as f32 / aspect_ratio) as usize,
-                    )
-                } else if width > height && width > max_image_size {
-                    (
-                        (max_image_size as f32 * aspect_ratio) as usize,
-                        max_image_size,
-                    )
-                } else {
-                    (height, width)
-                }
+                // First resize to max_longest_edge (always scale to this size)
+                let scale1 = max_longest_edge_for_image_resize as f32 / h.max(w);
+                let (h, w) = (h * scale1, w * scale1);
+
+                // Ensure we dont exceed max_size (only scale down)
+                let scale2 = (max_image_size as f32 / h.max(w)).min(1.0);
+
+                ((h * scale2) as usize, (w * scale2) as usize)
             };
 
             let image_seq_len = config.get_number_of_features();


### PR DESCRIPTION
server:
text-generation-launcher --model-id=HuggingFaceM4/Idefics3-8B-Llama3 -p 8080

client
curl -N 0.0.0.0:8080/generate_stream \
            -X POST \
                -d '{"inputs":"![](https://llava-vl.github.io/static/images/view.jpg)What is in the picture?\n\n","parameters":{"max_new_tokens":100, "seed": 42, "do_sample":true}}' \
                    -H 'Content-Type: application/json'

crash happens because slot allocated in rust is not large enough.
gaudi and XPU has the same issue, assume cuda has same issue too.
the image process logic is copied from https://github.com/huggingface/transformers/blob/main/src/transformers/models/idefics3/image_processing_idefics3.py#L118


