### PR TITLE
feat: allow json_schema in response format and add test

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1738,9 +1738,10 @@
         "oneOf": [
           {
             "type": "object",
+            "description": "A string that represents a [JSON Schema](https://json-schema.org/).\n\nJSON Schema is a declarative language that allows to annotate JSON documents\nwith types and descriptions.",
             "required": [
-              "type",
-              "value"
+              "value",
+              "type"
             ],
             "properties": {
               "type": {
@@ -1749,16 +1750,21 @@
                   "json"
                 ]
               },
-              "value": {
-                "description": "A string that represents a [JSON Schema](https://json-schema.org/).\n\nJSON Schema is a declarative language that allows to annotate JSON documents\nwith types and descriptions."
+              "value": {}
+            },
+            "example": {
+              "properties": {
+                "location": {
+                  "type": "string"
+                }
               }
             }
           },
           {
             "type": "object",
             "required": [
-              "type",
-              "value"
+              "value",
+              "type"
             ],
             "properties": {
               "type": {
@@ -1773,22 +1779,25 @@
             }
           },
           {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "json_schema"
-                ]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonSchemaFormat"
               },
-              "value": {
-                "$ref": "#/components/schemas/JsonSchemaConfig"
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "json_schema"
+                    ]
+                  }
+                }
               }
-            }
+            ]
           }
         ],
         "discriminator": {
@@ -1897,6 +1906,40 @@
             "description": "The actual JSON schema definition"
           }
         }
+      },
+      "JsonSchemaFormat": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "json_schema"
+            ],
+            "properties": {
+              "json_schema": {
+                "$ref": "#/components/schemas/JsonSchemaOrConfig"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "value"
+            ],
+            "properties": {
+              "value": {
+                "$ref": "#/components/schemas/JsonSchemaOrConfig"
+              }
+            }
+          }
+        ]
+      },
+      "JsonSchemaOrConfig": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/JsonSchemaConfig"
+          },
+          {}
+        ]
       },
       "Message": {
         "allOf": [

--- a/integration-tests/models/__snapshots__/test_json_schema_constrain/test_json_schema_openai_style_format.json
+++ b/integration-tests/models/__snapshots__/test_json_schema_constrain/test_json_schema_openai_style_format.json
@@ -1,0 +1,23 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "logprobs": null,
+      "message": {
+        "content": "{\"status\":\".OK.\"}",
+        "role": "assistant"
+      }
+    }
+  ],
+  "created": 1750877897,
+  "id": "",
+  "model": "google/gemma-3-4b-it",
+  "object": "chat.completion",
+  "system_fingerprint": "3.3.4-dev0-native",
+  "usage": {
+    "completion_tokens": 8,
+    "prompt_tokens": 36,
+    "total_tokens": 44
+  }
+}

--- a/integration-tests/models/__snapshots__/test_json_schema_constrain/test_json_schema_simple_status.json
+++ b/integration-tests/models/__snapshots__/test_json_schema_constrain/test_json_schema_simple_status.json
@@ -1,0 +1,23 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "logprobs": null,
+      "message": {
+        "content": "{\"status\":\".OK.\"}",
+        "role": "assistant"
+      }
+    }
+  ],
+  "created": 1750877897,
+  "id": "",
+  "model": "google/gemma-3-4b-it",
+  "object": "chat.completion",
+  "system_fingerprint": "3.3.4-dev0-native",
+  "usage": {
+    "completion_tokens": 8,
+    "prompt_tokens": 36,
+    "total_tokens": 44
+  }
+}

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -28,7 +28,7 @@ use crate::{
     ChatRequest, Chunk, CompatGenerateRequest, Completion, CompletionComplete, CompletionFinal,
     CompletionRequest, CompletionType, DeltaToolCall, Function, Prompt, Tool,
 };
-use crate::{ChatTokenizeResponse, JsonSchemaConfig};
+use crate::{ChatTokenizeResponse, JsonSchemaConfig, JsonSchemaFormat, JsonSchemaOrConfig};
 use crate::{FunctionDefinition, HubPreprocessorConfig, ToolCall, ToolChoice};
 use crate::{MessageBody, ModelInfo, ModelsInfo};
 use async_stream::__private::AsyncStream;
@@ -1363,6 +1363,8 @@ SagemakerRequest,
 GenerateRequest,
 GrammarType,
 JsonSchemaConfig,
+JsonSchemaOrConfig,
+JsonSchemaFormat,
 ChatRequest,
 Message,
 MessageContent,

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -350,13 +350,13 @@ impl Validation {
                     return Err(ValidationError::Grammar);
                 }
                 let valid_grammar = match grammar {
-                    GrammarType::Json(json) => {
-                        let json = match json {
+                    GrammarType::Json { value } => {
+                        let json = match value {
                             // if value is a string, we need to parse it again to make sure its
                             // a valid json
                             Value::String(s) => serde_json::from_str(&s)
                                 .map_err(|e| ValidationError::InvalidGrammar(e.to_string())),
-                            Value::Object(_) => Ok(json),
+                            Value::Object(_) => Ok(value),
                             _ => Err(ValidationError::Grammar),
                         }?;
 
@@ -380,9 +380,9 @@ impl Validation {
 
                         ValidGrammar::Regex(grammar_regex.to_string())
                     }
-                    GrammarType::JsonSchema(schema_config) => {
+                    GrammarType::JsonSchema(json_schema) => {
                         // Extract the actual schema for validation
-                        let json = &schema_config.schema;
+                        let json = json_schema.schema_value();
 
                         // Check if the json is a valid JSONSchema
                         jsonschema::draft202012::meta::validate(json)
@@ -402,7 +402,7 @@ impl Validation {
 
                         ValidGrammar::Regex(grammar_regex.to_string())
                     }
-                    GrammarType::Regex(regex) => ValidGrammar::Regex(regex),
+                    GrammarType::Regex { value } => ValidGrammar::Regex(value),
                 };
                 Some(valid_grammar)
             }


### PR DESCRIPTION
This PR improve the `response_format.type = "json_schema"` to allow the schema to be specified with the key `value` or `json_schema`, prior to these changes only the `value` key would be allowed.

These changes enable the two following request to succeed:

 ```python
import requests
import json

# API endpoint
url = "http://localhost:3000/v1/chat/completions"

# Your payload
payload = {
    "temperature": 0,
    "response_format": {
        "value": {
            "name": "test",
            "strict": True,
            "schema": {
                "type": "object",
                "properties": {"status": {"type": "string"}},
                "required": ["status"],
                "additionalProperties": False,
            },
        },
        "type": "json_schema",
    },
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful assistant. You answer with a JSON output with a status string containing the value \u0027OK\u0027",
        },
        {"role": "user", "content": "Please tell me OK"},
    ],
    "model": "tgi",
    "max_completion_tokens": 8192,
}

payload1 = {
   "temperature": 0,
   "response_format": {
       "json_schema": {
           "name": "test",
           "strict": True,
           "schema": {
               "type": "object",
               "properties": {"status": {"type": "string"}},
               "required": ["status"],
               "additionalProperties": False,
           },
       },
       "type": "json_schema",
   },
   "messages": [
       {
           "role": "system",
           "content": "You are a helpful assistant. You answer with a JSON output with a status string containing the value \u0027OK\u0027",
       },
       {"role": "user", "content": "Please tell me OK"},
   ],
   "model": "tgi",
   "max_completion_tokens": 8192,
}

# Send request
for payload in [payload, payload1]:
   response = requests.post(url, json=payload)

   # Print response
   print("Status Code:", response.status_code)
   print("Response JSON:", json.dumps(response.json(), indent=4))

 ```