### PR TITLE
feat: bump flake including transformers and huggingface_hub versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -586,11 +586,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1747919133,
-        "narHash": "sha256-VvF1naQOvv7yulQ5/cDiaxkNxlh1Y84QMZnderv1szk=",
+        "lastModified": 1756135149,
+        "narHash": "sha256-3BIGJkpmRGpGIMmUM3iT+GovVLZSfbM2+MjkWVNV6tA=",
         "owner": "huggingface",
         "repo": "hf-nix",
-        "rev": "9c71e026d6c7c8588ef85a5f7c77f57d598e038c",
+        "rev": "1e2afb51150816cb08bf7eeb0c59ff181e0c2e34",
         "type": "github"
       },
       "original": {
@@ -738,17 +738,17 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1747820358,
-        "narHash": "sha256-fTqsZsUX6M3yeEvgyQvXcbGmT2CaRVyVwsi8eK29Oj4=",
-        "owner": "danieldk",
+        "lastModified": 1752785354,
+        "narHash": "sha256-Y33ryUz7MPqKrZwlbQcsYCUz2jAJCacRf8jbs0tYUlA=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3c1681180717528068082103bf323147de6ab0b",
+        "rev": "d38025438a6ee456758dc03188ca6873a415463b",
         "type": "github"
       },
       "original": {
-        "owner": "danieldk",
-        "ref": "cudatoolkit-12.9-kernel-builder",
+        "owner": "nixos",
         "repo": "nixpkgs",
+        "rev": "d38025438a6ee456758dc03188ca6873a415463b",
         "type": "github"
       }
     },
@@ -873,11 +873,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743993291,
-        "narHash": "sha256-u8GHvduU1gCtoFXvTS/wGjH1ouv5S/GRGq6MAT+sG/k=",
+        "lastModified": 1756197489,
+        "narHash": "sha256-S16rPaBH1TnMbDyL5NlGSJcYd7wPlOEWTStdBDL7BHw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0cb3c8979c65dc6a5812dfe67499a8c7b8b4325b",
+        "rev": "8ec04f46f1edeeed3f870da62191745b93975da7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -305,11 +305,11 @@
     },
     "flake-compat_4": {
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1756135149,
-        "narHash": "sha256-3BIGJkpmRGpGIMmUM3iT+GovVLZSfbM2+MjkWVNV6tA=",
+        "lastModified": 1756232942,
+        "narHash": "sha256-Gyl/jRFM/knmBT0emDj+ztXgqxPOzZe56XBKsB5Qjp8=",
         "owner": "huggingface",
         "repo": "hf-nix",
-        "rev": "1e2afb51150816cb08bf7eeb0c59ff181e0c2e34",
+        "rev": "97a12921c8bb5cd6693b2591359e18b8864ffdb7",
         "type": "github"
       },
       "original": {
@@ -738,17 +738,17 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1752785354,
-        "narHash": "sha256-Y33ryUz7MPqKrZwlbQcsYCUz2jAJCacRf8jbs0tYUlA=",
+        "lastModified": 1755963616,
+        "narHash": "sha256-6yD0ww/S8n+U2uPYcJZ3DRURP8Kx036GRpR2uPNZroE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d38025438a6ee456758dc03188ca6873a415463b",
+        "rev": "73e96df7cff5783f45e21342a75a1540c4eddce4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
-        "rev": "d38025438a6ee456758dc03188ca6873a415463b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
         };
         pkgs = import nixpkgs {
           inherit system;
-          inherit (hf-nix.lib) config;
+          config = hf-nix.lib.config system;
           overlays = [
             rust-overlay.overlays.default
             hf-nix.overlays.default

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -33,6 +33,15 @@ final: prev: {
         #    };
         #  }
         #);
+
+        outlines = python-super.outlines.overridePythonAttrs (old: {
+          version = "0.1.13";
+          src = fetchPypi {
+            pname = "outlines";
+            version = "0.1.13";
+            hash = "sha256-AjPLP/rpy2sBrY08MrfYfj8c973HsooLyCzT0nfAm8o=";
+          };
+        });
       }
     )
   ];


### PR DESCRIPTION
This pr bumps the nix flake to use the latest version of hf-nix which bumps many python dependencies. Namely this updates to `transformers==4.55.0`



all updates diff shown below:

```diff
4c4
< Markdown==3.7
---
> Markdown==3.8
9,11c9,11
< absl-py==2.2.1
< accelerate==1.5.2
< aiodns==3.2.0
---
> absl-py==2.2.2
> accelerate==1.7.0
> aiodns==3.5.0
13c13
< aiohttp==3.11.15
---
> aiohttp==3.12.13
15c15
< airportsdata==20250224
---
> airportsdata==20250523
22c22
< certifi==2025.1.31
---
> certifi==2025.4.26
25c25
< charset-normalizer==3.4.1
---
> charset-normalizer==3.4.2
29,30c29,31
< datasets==3.5.1
< dill==0.3.9
---
> cramjam==2.10.0
> datasets==3.6.0
> dill==0.4.0
36c37
< einops==0.8.0
---
> einops==0.8.1
38a40
> fastparquet==2024.11.0
42,45c44,46
< frozenlist==1.5.0
< fsspec==2025.3.1
< future==1.0.0
< googleapis-common-protos==1.69.2
---
> frozenlist==1.6.0
> fsspec==2025.3.2
> googleapis-common-protos==1.70.0
47,51c48,52
< grpcio-reflection==1.71.0
< grpcio-status==1.71.0
< grpcio-tools==1.71.0
< grpcio==1.71.0
< hf-xet==1.0.0
---
> grpcio-reflection==1.73.1
> grpcio-status==1.73.1
> grpcio-tools==1.73.1
> grpcio==1.73.1
> hf-xet==1.1.5
53,55c54,56
< huggingface_hub==0.30.2
< hypothesis==6.130.12
< identify==2.6.10
---
> huggingface_hub==0.34.4
> hypothesis==6.131.17
> identify==2.6.12
57c58
< importlib_metadata==8.6.1
---
> importlib_metadata==8.7.0
60c61
< jsonschema-specifications==2024.10.1
---
> jsonschema-specifications==2025.4.1
62c63
< kernels==0.2.1
---
> kernels==0.7.0
65c66
< mamba_ssm==2.2.2
---
> mamba_ssm==2.2.4
70,71c71,72
< multidict==6.2.0
< multiprocess==0.70.17
---
> multidict==6.4.4
> multiprocess==0.70.18
76c77
< numpy==2.2.5
---
> numpy==2.3.1
89c90
< packaging==24.2
---
> packaging==25.0
93,97c94,98
< pillow==11.2.0
< platformdirs==4.3.7
< pluggy==1.5.0
< pre_commit==4.0.1
< prometheus_client==0.21.1
---
> pillow==11.3.0
> platformdirs==4.3.8
> pluggy==1.6.0
> pre_commit==4.2.0
> prometheus_client==0.22.0
99c100
< protobuf==6.30.2
---
> protobuf==6.31.1
103c104
< pyarrow==19.0.1
---
> pyarrow==20.0.0
105c106
< pycares==4.5.0
---
> pycares==4.9.0
108,109c109,110
< pydantic==2.11.1
< pydantic_core==2.33.0
---
> pydantic==2.11.4
> pydantic_core==2.33.2
118c119
< requests==2.32.3
---
> requests==2.32.4
122,124c123,125
< rpds-py==0.24.0
< ruff==0.11.8
< safetensors==0.5.2
---
> rpds-py==0.25.0
> ruff==0.12.3
> safetensors==0.6.0.dev0
126c127
< setuptools==78.1.0.post0
---
> setuptools==80.7.1.post0
130c131,132
< sympy==1.13.3
---
> standard-imghdr==3.13.0
> sympy==1.14.0
136c138
< tokenizers==0.21.1
---
> tokenizers==0.21.4.dev0
138c140
< torch==2.7.0
---
> torch==2.7.1
140,142c142,144
< transformers==4.51.3
< triton==3.1.0
< typer==0.15.2
---
> transformers==4.55.0
> triton==3.3.1
> typer==0.15.4
146,147c148,149
< typing-inspection==0.4.0
< typing_extensions==4.13.0
---
> typing-inspection==0.4.1
> typing_extensions==4.13.2
150,151c152,154
< urllib3==2.3.0
< virtualenv==20.30.0
---
> urllib3==2.4.0
> virtualenv==20.31.2
> websockets==15.0.1
155c158
< yarl==1.18.3
---
> yarl==1.20.1

```