### PR TITLE
fix: don't use kernel layernorm on Blackwell architecture to avoid "no kernel image" error

### DIFF
--- a/server/text_generation_server/layers/layernorm.py
+++ b/server/text_generation_server/layers/layernorm.py
@@ -36,9 +36,12 @@ torch.nn.LayerNorm.load_no_bias = load_layer_norm_no_bias
 if SYSTEM == "cuda":
     import dropout_layer_norm
 
+    major, _ = torch.cuda.get_device_capability()
+    is_blackwell = major > 9
+
     class FastLayerNorm(nn.LayerNorm):
         def forward(self, hidden_states, residual=None):
-            if hidden_states.shape[-1] > 8192:
+            if hidden_states.shape[-1] > 8192 or is_blackwell:
                 if residual is not None:
                     hidden_states += residual
                 residual = hidden_states
@@ -142,7 +145,7 @@ class FastRMSNorm(nn.Module):
                 self.variance_epsilon,
             )
             return out, residual
-        elif hidden_states.shape[-1] > 8192:
+        elif hidden_states.shape[-1] > 8192 or is_blackwell:
             if residual is not None:
                 hidden_states += residual
             residual = hidden_states


### PR DESCRIPTION
When running models with FastLayerNorm (like Llama) on Blackwell GPUs (eg. RTX 5060 Ti), the following error occurs:

`CUDA Error: no kernel image is available for execution on the device /usr/src/flash-attention/csrc/layer_norm/ln_fwd_kernels.cuh 236 rank=0`

This happens because the FastLayerNorm CUDA kernel is not compiled for the Blackwell compute capability (12.0 for RTX 5xxx), but the code still attempts to use it.

## What this PR does

- Adds a simple compute capability check:

  ```python
  major, _ = torch.cuda.get_device_capability()
  is_blackwell = major > 9
  
Fixes # (issue)
Fixing https://github.com/huggingface/text-generation-inference/issues/3342

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
