### PR TITLE
 fix(num_devices): fix num_shard/num device auto compute when NVIDIA_VISIBLE_DEVICES == "all" or "void"

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1264,7 +1264,12 @@ fn num_cuda_devices() -> Option<usize> {
         Ok(devices) => devices,
         Err(_) => match env::var("NVIDIA_VISIBLE_DEVICES") {
             Ok(devices) => {
-                if devices.trim() == "all" {
+                // NVIDIA_VISIBLE_DEVICES is always set when not specified and the nvidia container runtime is
+                // in (jit-)cdi mode (since 1.14)
+                // nvidia container runtime default mode switched from legacy to cdi mode from 1.18 on
+                // Let's handle the void case as all here
+                // See: https://github.com/NVIDIA/nvidia-container-toolkit
+                if ["all", "void"].contains(&devices.trim())  {
                     // Count the number of all GPUs via nvidia-smi
                     let output = Command::new("nvidia-smi")
                         .args(["--query-gpu=uuid", "--format=csv,noheader"])


### PR DESCRIPTION
If NVIDIA_VISIBLE_DEVICES == "all" then auto computed num shards was always 1
NVIDIA_VISIBLE_DEVICES == "void" is a new value coming from nvidia container runtime > 1.18